### PR TITLE
Added Dockerfile and updated README on how to use docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:latest
+
+RUN mkdir -p /go/src/github.com/ardanlabs
+#
+# downloading the latest gotraining material so that it allows to
+# run the container without mapping to any local gotraining copy
+# e.g.
+#       docker build -t ardanlabs-gotraining .
+#       docker run -it ardanlabs-gotraining
+#
+RUN git clone https://github.com/ardanlabs/gotraining /go/src/github.com/ardanlabs/gotraining
+
+RUN mkdir -p /go/src/github.com/ardanlabs/gotraining
+
+WORKDIR /go/src/github.com/ardanlabs/gotraining
+
+CMD /bin/bash

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ We use a slack channel to share links, code, and examples during the training.  
 
 ### Installing Go
 
+**Using Docker container**   
+Installing Go may not be needed if you choose using [Docker container](#docker). With running a gotraining container, you can download the training material at any location on your disk without having to set ```$GOPATH```. And you can still access (e.g. for editing) the training materials locally.
+
+```
+git clone https://github.com/ardanlabs/gotraining.git
+cd gotraining
+```
+
+*NOTE:* This assumes you have Git installed.  If you don’t, you can find the installation instructions here: https://git-scm.com/
+
+To build and run docker container to start your training right away, see [here](#docker).
+
 **Mac OS X**  
 http://www.goinggo.net/2013/06/installing-go-gocode-gdb-and-liteide.html
 
@@ -108,6 +120,34 @@ git clone https://github.com/ardanlabs/gotraining.git
 ```
 
 *NOTE:* This assumes you have Git installed.  If you don’t, you can find the installation instructions here: https://git-scm.com/
+
+
+###<a name="docker" />Starting gotraining in Docker container
+
+**Install Docker Toolbox**  
+https://www.docker.com/products/docker-toolbox
+
+**Build Docker container**
+
+```
+# current path is the source root where Dockerfile exists
+docker build -t ardanlabs-gotraining .
+```
+
+**Start Docker container**
+
+```
+docker run -it -v "$PWD":/go/src/github.com/ardanlabs/gotraining ardanlabs-gotraining
+# or start container with downloaded gotraining in the image
+docker run -it ardanlabs-gotraining
+```
+
+**Remove gotraining container and image**
+
+```
+docker rm -f $(docker ps -a | grep ardanlabs-gotraining | awk '{print $1}')
+docker rmi -f $(docker images -a | grep ardanlabs-gotraining | awk '{print $1}')
+```
 
 ## Starter Material
   


### PR DESCRIPTION
This PR includes
  - adding a Dockerfile to allow starting to use the material in a docker container
  - updating README with instructions on how to build and run gotraining container

Note: Using docker container will enable any user to start using the gotraining material right away without having to install and setup go. And it can be easily removed after use.