### PR TITLE
Spelling, wording, link, and clarification fixes

### DIFF
--- a/tools/mpl/README.md
+++ b/tools/mpl/README.md
@@ -3,7 +3,7 @@
 This tool processes markdown files from the training materials to automatically
 update "Go Playground" links with the latest code from the linked samples.
 
-It will find mardown like the following and automatically update it:
+It will find markdown like the following and automatically update it:
 
 ```
 The following link will automatically be updated
@@ -13,7 +13,7 @@ The following link will automatically be updated
 The program searches for a link followed by a "([Go Playground](.*))" link.
 ```
 
-You can use an empty playground link and it will be automatically popullated
+You can use an empty playground link and it will be automatically populated
 with the right link.
 
 ## Usage

--- a/topics/composition/README.md
+++ b/topics/composition/README.md
@@ -8,7 +8,7 @@ Composition goes beyond the mechanics of type embedding and is more than just a 
 * Declare types and implement workflows with composition in mind.
 * Understand the problem you are trying to solve first. This means understanding the data.
 * The goal is to reduce and minimize cascading changes across your software.
-* Interfaces provide the highest form composition.
+* Interfaces provide the highest form of composition.
 
 ## Links
 

--- a/topics/composition/example5/example5.go
+++ b/topics/composition/example5/example5.go
@@ -59,7 +59,7 @@ func main() {
 	// interface value.
 	ml = bike{}
 
-	// An interface value of type MoveLocker can be implicitly convered into
+	// An interface value of type MoveLocker can be implicitly converted into
 	// a value of type Mover. They both declare a method named move.
 	m = ml
 
@@ -71,7 +71,7 @@ func main() {
 	// Therefore, the compiler can't perform an implicit conversion to assign
 	// a value of interface type Mover to an interface value of type MoveLocker.
 	// It is irrelevant that the concrete type value of type bike that is stored
-	// inside of the Mover interfae value implements the MoveLocker interface.
+	// inside of the Mover interface value implements the MoveLocker interface.
 
 	// We can perform a type assertion at runtime to support the assignment.
 

--- a/topics/embedding/README.md
+++ b/topics/embedding/README.md
@@ -1,10 +1,10 @@
 ## Embedding
 
-Embedding types provides the final piece of sharing and reusing state and behavior between types. Through the use of inner type promotion, an inner type's fields and methods can be directly access by references of the outer type.
+Embedding types provides the final piece of sharing and reusing state and behavior between types. Through the use of inner type promotion, an inner type's fields and methods can be directly accessed by references of the outer type.
 
 ## Notes
 
-* Embedding types allow us to share state or behavior between types.
+* Embedding types allows us to share state or behavior between types.
 * The inner type never loses its identity.
 * This is not inheritance.
 * Through promotion, inner type fields and methods can be accessed through the outer type.

--- a/topics/exporting/README.md
+++ b/topics/exporting/README.md
@@ -41,7 +41,7 @@ _I think that the real problem with C is that it doesn't give you enough mechani
 [Unexported struct type fields - Pkg](example4/users/users.go) ([Go Playground](http://play.golang.org/p/O9hleQ18dT))  
 [Unexported struct type fields - Main](example4/example4.go) ([Go Playground](http://play.golang.org/p/LpjLP_bIKS))  
 
-[Unexported embedded types - Pkg](example4/users/users.go) ([Go Playground](http://play.golang.org/p/O9hleQ18dT))  
+[Unexported embedded types - Pkg](example5/users/users.go) ([Go Playground](https://play.golang.org/p/RWpldbVNJe))  
 [Unexported embedded types - Main](example5/example5.go) ([Go Playground](http://play.golang.org/p/_1QiymFuw5))  
 
 ## Exercises

--- a/topics/interfaces/example2/example2.go
+++ b/topics/interfaces/example2/example2.go
@@ -1,7 +1,7 @@
 // All material is licensed under the Apache License Version 2.0, January 2004
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// Sample program to show how to understand the important of method sets.
+// Sample program to show how to understand method sets.
 package main
 
 import "fmt"

--- a/topics/methods/README.md
+++ b/topics/methods/README.md
@@ -7,7 +7,7 @@ Methods are functions that are declared with a receiver which binds the method t
 * Methods are functions that contain a receiver value.
 * Receivers bind a method to a type and can be value or pointers.
 * Methods are called against values and pointers, not packages.
-* Go support function and method variables.
+* Go supports function and method variables.
 
 ## Links
 
@@ -16,7 +16,7 @@ http://www.goinggo.net/2014/05/methods-interfaces-and-embedded-types.html
 
 ## Code Review
 
-[Declare and receiver behavior](example1/example1.go) ([Go Playground](http://play.golang.org/p/haHeUTsJQR))  
+[Declare and receiver behavior](example1/example1.go) ([Go Playground](https://play.golang.org/p/nxAwTRWk4N))  
 [Named typed methods](example2/example2.go) ([Go Playground](http://play.golang.org/p/9WeR1rShIa))
 
 ## Advanced Code Review

--- a/topics/methods/example1/example1.go
+++ b/topics/methods/example1/example1.go
@@ -39,12 +39,12 @@ func main() {
 
 	// Values of type user can be used to call methods
 	// declared with a pointer receiver.
-	bill.changeEmail("bill@gmail.com")
+	bill.changeEmail("bill@hotmail.com")
 	bill.notify()
 
 	// Pointers of type user can be used to call methods
 	// declared with a pointer receiver.
-	lisa.changeEmail("lisa@gmail.com")
+	lisa.changeEmail("lisa@hotmail.com")
 	lisa.notify()
 
 	// Create a slice of users with two users.

--- a/topics/slices/README.md
+++ b/topics/slices/README.md
@@ -25,7 +25,7 @@ http://www.goinggo.net/2013/12/three-index-slices-in-go-12.html
 [Declare and Length](example1/example1.go) ([Go Playground](http://play.golang.org/p/lDKravTEqF))  
 [Reference Types](example2/example2.go) ([Go Playground](http://play.golang.org/p/gVWb35XjwM))  
 [Appending slices](example4/example4.go) ([Go Playground](http://play.golang.org/p/x4hGDV1phU))  
-[Taking slices of slices](example3/example3.go) ([Go Playground](http://play.golang.org/p/GSn0vrOPva))  
+[Taking slices of slices](example3/example3.go) ([Go Playground](https://play.golang.org/p/Okc2EZG5_M))  
 [Strings and slices](example5/example5.go) ([Go Playground](http://play.golang.org/p/wFO4ZxMwIr))  
 [Variadic functions](example6/example6.go) ([Go Playground](http://play.golang.org/p/sNGBMa05t-))
 

--- a/topics/slices/example3/example3.go
+++ b/topics/slices/example3/example3.go
@@ -26,7 +26,7 @@ func main() {
 
 	fmt.Println("*************************")
 
-	// Change the value of the index 0 of slice3.
+	// Change the value of the index 0 of slice2.
 	slice2[0] = "CHANGED"
 
 	// Display the change across all existing slices.


### PR DESCRIPTION
- General spelling and grammar fixes
- In `topics/exporting/README.md` there is a link to the lib for
  `example4` where it should have be `example5`
- In `topics/methods/example1/example1.go` we show changing a value from
  `email.com` to `gmail.com` which is only one letter different. It
  seems like it would be easy to miss the difference so I changed it to
  `hotmail.com` :)