### PR TITLE
add answer example for "find the bug" in error_handling

### DIFF
--- a/topics/error_handling/README.md
+++ b/topics/error_handling/README.md
@@ -24,7 +24,8 @@ http://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully
 [Error Variables](example2/example2.go) ([Go Playground](http://play.golang.org/p/-vBG0m1Scs))  
 [Type As Context](example3/example3.go) ([Go Playground](http://play.golang.org/p/FeR2nE3eAH))  
 [Behavior As Context](example4/example4.go) ([Go Playground](http://play.golang.org/p/Aylgou6Gq0))  
-[Find The Bug](example5/example5.go) ([Go Playground](http://play.golang.org/p/0AUU_sJsec))
+[Find The Bug](example5/example5.go) ([Go Playground](http://play.golang.org/p/0AUU_sJsec)) | 
+[Answer](example5/example5answer.go) ([Go Playground](https://play.golang.org/p/Yy9-h-9Qct))
 
 ## Exercises
 


### PR DESCRIPTION
This is definitely a subtle bug.  An answer example with an inner and outer
print of the type shows how the unexpected comparison happens in a strongly
typed language.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>