### PR TITLE
change `go-wrk -M` to `go-wrk -m`

### DIFF
--- a/topics/profiling/README.md
+++ b/topics/profiling/README.md
@@ -35,7 +35,7 @@ We have a website that we will use to learn and explore more about profiling. Th
 To add load to the service while running profiling we can run these command.
 
 	Use 10 connections for 2 minute on CNN, BBC and NYT about house:
-	go-wrk -M POST -c 10 -d 120 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
+	go-wrk -m POST -c 10 -d 120 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
 
 ## GODEBUG
 
@@ -54,7 +54,7 @@ Run the website redirecting the stdout (logs) to the null device. This will allo
 
 Put some load of the web application for 20 seconds.
 
-	go-wrk -M POST -c 10 -d 20 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
+	go-wrk -m POST -c 10 -d 20 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
 
 ### Scheduler Trace for Project
 
@@ -64,7 +64,7 @@ Run the website redirecting the stdout (logs) to the null device. This will allo
 
 Put some load of the web application for 20 seconds.
 
-	go-wrk -M POST -c 10 -d 20 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
+	go-wrk -m POST -c 10 -d 20 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
 
 ## PPROF
 
@@ -91,7 +91,7 @@ Run a single search from the Browser and then refresh the profile information.
 
 Put some load of the web application for 10 seconds. Review the raw profiling information once again.
 
-	go-wrk -M POST -c 10 -d 10 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
+	go-wrk -m POST -c 10 -d 10 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
 
 ### Interactive Profiling
 
@@ -99,7 +99,7 @@ Using the Go pprof tool we can interact with the profiling data.
 
 Put some load of the web application for 2 minutes using a single connection.
 
- 	go-wrk -M POST -c 1 -d 120 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
+ 	go-wrk -m POST -c 1 -d 120 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
 
 Run the Go pprof tool in another window or tab to review heap information.
 
@@ -136,7 +136,7 @@ Tool for stochastically profiling Go programs. Collects stack traces and synthes
 
 Put some load of the web application for 2 minutes.
 
-	go-wrk -M POST -c 10 -d 120 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
+	go-wrk -m POST -c 10 -d 120 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
 
 Run the torch tool and visualize the profile.
 
@@ -169,7 +169,7 @@ Run the web application with tracing on. Show the code that produces the trace.
 
 Put some load of the web application for 2 minutes.
 
-	go-wrk -M POST -c 10 -d 120 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
+	go-wrk -m POST -c 10 -d 120 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
 
 Kill the web application to produce the trace.out file.
 

--- a/topics/profiling/godebug/schedtrace/README.md
+++ b/topics/profiling/godebug/schedtrace/README.md
@@ -33,7 +33,7 @@ This example shows a simple web api running with some basic load.
 
 	Start to apply load to the web api for 5 seconds.
 
-		go-wrk -M POST -c 500 -d 5 "http://localhost:4000/sendjson"
+		go-wrk -m POST -c 500 -d 5 "http://localhost:4000/sendjson"
 	
 	Look at the load on the logical processor. We can only see runnable goroutines. After 5 seconds
 	we don't see any more goroutines in the trace.
@@ -49,7 +49,7 @@ This example shows a simple web api running with some basic load.
 
 	Start to apply load to the web api for 5 seconds.
 
-		go-wrk -M POST -c 500 -d 5 "http://localhost:4000/sendjson"
+		go-wrk -m POST -c 500 -d 5 "http://localhost:4000/sendjson"
 	
 	Look at the load on the logical processor. We can only see runnable goroutines. After 5 seconds
 	we still see goroutines in the trace.


### PR DESCRIPTION
This PR changes to `go-wrk -m` instead of `-M.` The lowercase flag is the one for sending a specific HTTP method as of go-wrk as of this commit: https://github.com/adjust/go-wrk/commit/71f7f2794f958abbaf6538df7d708a8873eb1756

`go-wrk -M` doesn't work