### PR TITLE
Leverage pprof endpoints for execution traces

### DIFF
--- a/topics/profiling/README.md
+++ b/topics/profiling/README.md
@@ -163,15 +163,17 @@ Now compare both snapshots against the binary and get into the pprof tool:
 
 ## Tracing
 
-Run the web application with tracing on. Show the code that produces the trace.
+Run the web application.
 
-	./project trace
+	./project
 
 Put some load of the web application for 2 minutes.
 
 	go-wrk -M POST -c 10 -d 120 -no-ka "http://localhost:5000/search?term=house&cnn=on&bbc=on&nyt=on"
 
-Kill the web application to produce the trace.out file.
+Capture a trace file for a brief duration.
+
+	curl -s http://localhost:5000/debug/pprof/trace?seconds=2 > trace.out
 
 Run the Go trace tool.
 

--- a/topics/profiling/project/main.go
+++ b/topics/profiling/project/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	_ "net/http/pprof"
 	"os"
-	"runtime/trace"
 
 	"github.com/ardanlabs/gotraining/topics/profiling/project/service"
 )
@@ -20,18 +19,5 @@ func init() {
 
 // main is the entry point for the application.
 func main() {
-
-	// Quick way to turn on tracing when needed.
-	if len(os.Args) == 2 {
-		f, err := os.Create("trace.out")
-		if err != nil {
-			log.Fatalln(err)
-		}
-		defer f.Close()
-
-		trace.Start(f)
-		defer trace.Stop()
-	}
-
 	service.Run()
 }


### PR DESCRIPTION
Mentioned this briefly to William at the pre-kickoff party and he requested an email reminder; I figured a PR would be a more useful reminder (and a good use of a little hack day time) :)

During the Advanced Go workshop at GopherCon, the execution tracer example mentioned special code required to capture traces, and a command line arg was used to enable tracing for the process lifetime.  That's not actually required; the default endpoints exposed by `net/http/pprof` also expose execution trace captures, in an ad-hoc fashion.  This allows capturing more targeted traces of a shorter duration (vital given the 'information overload' nature of execution traces).

I've updated the code and the brief description in the README.md.

Thanks much for the training and making this content open sourced!