### PR TITLE
Add two more stream profiling examples.

### DIFF
--- a/topics/profiling/benchmarks/stream_test.go
+++ b/topics/profiling/benchmarks/stream_test.go
@@ -11,26 +11,62 @@ import (
 	"testing"
 )
 
+// assembleInputStream appends all the input slices together to allow for
+// consistent testing across all benchmarks.
+func assembleInputStream() []byte {
+	var out []byte
+	for _, d := range data {
+		out = append(out, d.input...)
+	}
+	return out
+}
+
 // Capture the time it takes to execute algorithm one.
 func BenchmarkAlgorithmOne(b *testing.B) {
 	var output bytes.Buffer
+	in := assembleInputStream()
 
 	for i := 0; i < b.N; i++ {
-		for _, d := range data {
-			output.Reset()
-			algorithmOne(d.input, &output)
-		}
+		output.Reset()
+		algorithmOne(in, &output)
 	}
 }
 
 // Capture the time it takes to execute algorithm two.
 func BenchmarkAlgorithmTwo(b *testing.B) {
 	var output bytes.Buffer
+	in := assembleInputStream()
 
 	for i := 0; i < b.N; i++ {
-		for _, d := range data {
-			output.Reset()
-			algorithmTwo(d.input, &output)
-		}
+		output.Reset()
+		algorithmTwo(in, &output)
+	}
+}
+
+// Capture the time it takes to execute algorithm three.
+func BenchmarkAlgorithmThree(b *testing.B) {
+	var output bytes.Buffer
+	in := bytes.NewReader(assembleInputStream())
+
+	for i := 0; i < b.N; i++ {
+		output.Reset()
+
+		// Seek our reader to the beginning of the byte array.
+		in.Seek(0, 0)
+		algorithmThree(in, &output)
+	}
+}
+
+// Capture the time it takes to execute algorithm four.
+func BenchmarkAlgorithmFour(b *testing.B) {
+	var output bytes.Buffer
+	in := bytes.NewReader(assembleInputStream())
+
+	for i := 0; i < b.N; i++ {
+		output.Reset()
+
+		// Seek our reader to the beginning of the byte array.
+		in.Seek(0, 0)
+		algorithmFour(in, &output)
 	}
 }


### PR DESCRIPTION
This PR adds two more example functions to the elvis stream benchmarking/profiling section. These two new examples take io.Reader to effectively work on an infinite stream, rather than a slice of bytes.

The third example is effectively the same as example two, but uses bufio instead of bytes as the reader into the io.Reader stream.

The fourth example is effectively the same, but reads directly to a buffer of our own, and skips the UnreadByte call by simply re-using the buffer in the case of a match.

In addition, the test file has been changed to allow all the benchmarks to start at zero allocations in the benchmark itself, isolating all work to the processing functions. This gives more accurate output in terms of allocations and time spent.