### PR TITLE
Correct link to tweet in Twitter section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ _Cory LaNou is a full stack web developer and entrepreneur with over 17 years of
 
 ## Twitter
 
-Ian Molee ([@ianfoo](https://twitter.com/c4milo/status/752317652563996672))  
+Ian Molee ([@ianfoo](https://twitter.com/ianfoo/status/752246569554964480))
 _"If you're at @GopherCon, get yourself to a session with @goinggodotnet. Superb! Pretty sure his pic appears with the definition of "dynamo.""_
 
 Camilo Aguilar ([@c4milo](https://twitter.com/c4milo/status/752317652563996672))  


### PR DESCRIPTION
Link for @ianfoo tweet actually pointed to a @c4milo's tweet.