### PR TITLE
Data science

### DIFF
--- a/topics/data_science/csv_cleaning/example4/example4.go
+++ b/topics/data_science/csv_cleaning/example4/example4.go
@@ -36,7 +36,7 @@ func main() {
 	defer tx.Commit()
 
 	// Define a SQL query that we will execute against the CSV file.
-	query := "SELECT var3, var4, var5 FROM csv WHERE var5 = \"Iris-versicolor\""
+	query := `SELECT var3, var4, var5 FROM csv WHERE var5 = "Iris-versicolor"`
 
 	// Query the CSV via the SQL statement.  Here we will only get
 	// the petal length, petal width, and species for all rows

--- a/topics/data_science/csv_cleaning/exercises/exercise2/exercise2.go
+++ b/topics/data_science/csv_cleaning/exercises/exercise2/exercise2.go
@@ -36,7 +36,7 @@ func main() {
 	defer tx.Commit()
 
 	// Define a query we will execute against our CSV file.
-	query := "SELECT var1, var2, var3, var4, var5 FROM csv WHERE var1 != \"sepal_length\";"
+	query := `SELECT var1, var2, var3, var4, var5 FROM csv WHERE var1 != "sepal_length";`
 
 	// Query the CSV via the SQL statement.
 	rows, err := tx.Query(query)

--- a/topics/data_science/csv_cleaning/exercises/exercise2/exercise2.go
+++ b/topics/data_science/csv_cleaning/exercises/exercise2/exercise2.go
@@ -74,4 +74,9 @@ func main() {
 			log.Fatal(err)
 		}
 	}
+
+	// Make sure the output file is properly saved.
+	if err := tbl.Close(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/topics/data_science/csv_io/example1/example1.go
+++ b/topics/data_science/csv_io/example1/example1.go
@@ -17,14 +17,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../data/iris.csv")
+	f, err := os.Open("../data/iris.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// Assume we don't know the number of fields per line.  By setting
 	// FieldsPerRecord negative, each row may have a variable

--- a/topics/data_science/csv_io/example2/example2.go
+++ b/topics/data_science/csv_io/example2/example2.go
@@ -18,14 +18,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../data/iris_extra_field.csv")
+	f, err := os.Open("../data/iris_extra_field.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// We should have 5 fields per line.  By setting
 	// FieldsPerRecord to 5, we can validate that each of the

--- a/topics/data_science/csv_io/example3/example3.go
+++ b/topics/data_science/csv_io/example3/example3.go
@@ -19,14 +19,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../data/iris_mixed_types.csv")
+	f, err := os.Open("../data/iris_mixed_types.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// secondColumn will hold the float values parsed from the second
 	// column of the CSV file.

--- a/topics/data_science/csv_io/example4/example4.go
+++ b/topics/data_science/csv_io/example4/example4.go
@@ -28,14 +28,14 @@ var data = [][]string{
 func main() {
 
 	// Create the output file.
-	file, err := os.Create("output.csv")
+	f, err := os.Create("output.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer file.Close()
+	defer f.Close()
 
 	// Create a CSV writer.
-	w := csv.NewWriter(file)
+	w := csv.NewWriter(f)
 
 	// Write all the records out to the file. Note, this can
 	// also we done record by record, with a final call to

--- a/topics/data_science/csv_io/exercises/exercise1/exercise1.go
+++ b/topics/data_science/csv_io/exercises/exercise1/exercise1.go
@@ -30,14 +30,14 @@ type CSVRecord struct {
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../../data/iris_multiple_mixed_types.csv")
+	f, err := os.Open("../../data/iris_multiple_mixed_types.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// Create a slice value that will hold all of the successfully parsed
 	// records from the CSV.

--- a/topics/data_science/csv_io/exercises/exercise2/exercise2.go
+++ b/topics/data_science/csv_io/exercises/exercise2/exercise2.go
@@ -69,6 +69,11 @@ func main() {
 	if err := w.Error(); err != nil {
 		log.Fatal(err)
 	}
+
+	// Make sure the file is correctly closed.
+	if err := f.Close(); err != nil {
+		log.Fatal(err)
+	}
 }
 
 // cleanFile parses and cleans the file similar to what we did in exercise1.

--- a/topics/data_science/csv_io/exercises/exercise2/exercise2.go
+++ b/topics/data_science/csv_io/exercises/exercise2/exercise2.go
@@ -55,14 +55,14 @@ func main() {
 	}
 
 	// Save the records to a CSV file called processed.csv.
-	file, err := os.Create("processed.csv")
+	f, err := os.Create("processed.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer file.Close()
+	defer f.Close()
 
 	// Create a CSV writer.
-	w := csv.NewWriter(file)
+	w := csv.NewWriter(f)
 
 	// Write all the records out to the file.
 	w.WriteAll(records)
@@ -75,14 +75,14 @@ func main() {
 func cleanFile(filename string) ([]CSVRecord, error) {
 
 	// Open the dataset file.
-	csvFile, err := os.Open(filename)
+	f, err := os.Open(filename)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// Create a slice value that will hold all of the successfully parsed
 	// records from the CSV.

--- a/topics/data_science/csv_io/exercises/template1/template1.go
+++ b/topics/data_science/csv_io/exercises/template1/template1.go
@@ -19,14 +19,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../../data/iris_multiple_mixed_types.csv")
+	f, err := os.Open("../../data/iris_multiple_mixed_types.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// Create a slice value that will hold all of the successfully parsed
 	// records from the CSV.

--- a/topics/data_science/csv_io/exercises/template2/template2.go
+++ b/topics/data_science/csv_io/exercises/template2/template2.go
@@ -46,14 +46,14 @@ func main() {
 func cleanFile(filename string) ([]CSVRecord, error) {
 
 	// Open the dataset file.
-	csvFile, err := os.Open(filename)
+	f, err := os.Open(filename)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// Create a slice value that will hold all of the successfully parsed
 	// records from the CSV.

--- a/topics/data_science/dimensionality_reduction/README.md
+++ b/topics/data_science/dimensionality_reduction/README.md
@@ -1,6 +1,6 @@
 ## Dimensionality Reduction
 
-Data scientists use dimensionality reduction to transfrom high-dimensional data sets into more compact, low-dimensional data sets.  This process can be very useful when there is redundancy and correlation between features, when a data set includes irrelevant features, and when computational or modeling constraints necessitate lower dimensions. Principle Component Analysis is a widely used dimensionality reduction technique that we will explore here.
+Data scientists use dimensionality reduction to transfrom high-dimensional data sets into more compact, low-dimensional data sets.  This process can be very useful when there is redundancy and correlation between features, when a data set includes irrelevant features, and when computational or modeling constraints necessitate lower dimensions. Principal Component Analysis is a widely used dimensionality reduction technique that we will explore here.
 
 ## Notes
 
@@ -14,14 +14,14 @@ Data scientists use dimensionality reduction to transfrom high-dimensional data 
 
 ## Links
 
-[A tutorial on principle component analysis](http://faculty.iiit.ac.in/~mkrishna/PrincipalComponents.pdf)    
-[Another tutorial on principle component analysis](https://www.cs.princeton.edu/picasso/mats/PCA-Tutorial-Intuition_jp.pdf)    
+[A tutorial on principal component analysis](http://faculty.iiit.ac.in/~mkrishna/PrincipalComponents.pdf)
+[Another tutorial on principal component analysis](https://www.cs.princeton.edu/picasso/mats/PCA-Tutorial-Intuition_jp.pdf)
 [A survey of dimensionality reduction techniques](http://computation.llnl.gov/casc/sapphire/pubs/148494.pdf)
 
 ## Code Review
 
 [github.com/gonum/stat docs](https://godoc.org/github.com/gonum/stat)  
-[Caclulate Principle Components](example1/example1.go)  
+[Calculate Principal Components](example1/example1.go)
 [Determine a Number of Target Dimensions](example2/example2.go)  
 [Project the Data](example3/example3.go)  
 

--- a/topics/data_science/dimensionality_reduction/example1/example1.go
+++ b/topics/data_science/dimensionality_reduction/example1/example1.go
@@ -21,14 +21,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../data/iris.csv")
+	f, err := os.Open("../data/iris.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 	reader.FieldsPerRecord = 5
 
 	// Read in all of the CSV records

--- a/topics/data_science/dimensionality_reduction/example1/example1.go
+++ b/topics/data_science/dimensionality_reduction/example1/example1.go
@@ -4,7 +4,7 @@
 // go build
 // ./example1
 
-// Sample program to illustrate the calculation of principle components.
+// Sample program to illustrate the calculation of principal components.
 package main
 
 import (
@@ -69,9 +69,9 @@ func main() {
 	// and variances.
 	_, vars, ok := stat.PrincipalComponents(mat, nil)
 	if !ok {
-		log.Fatal(fmt.Errorf("Could not calculate prinicple components"))
+		log.Fatal("Could not calculate principal components")
 	}
 
-	// Output the principle component direction variances to standard out.
+	// Output the principal component direction variances to standard out.
 	fmt.Printf("\nvariances = %.4f\n\n", vars)
 }

--- a/topics/data_science/dimensionality_reduction/example1/example1.go
+++ b/topics/data_science/dimensionality_reduction/example1/example1.go
@@ -53,7 +53,7 @@ func main() {
 			// Convert the value to a float.
 			val, err := strconv.ParseFloat(record[i], 64)
 			if err != nil {
-				log.Fatal(fmt.Errorf("Could not parse float value"))
+				log.Fatal("Could not parse float value")
 			}
 
 			// Add the float value to the slice of floats.

--- a/topics/data_science/dimensionality_reduction/example2/example2.go
+++ b/topics/data_science/dimensionality_reduction/example2/example2.go
@@ -75,7 +75,7 @@ func main() {
 	// and variances.
 	_, vars, ok := stat.PrincipalComponents(mat, nil)
 	if !ok {
-		log.Fatal(fmt.Errorf("Could not calculate prinicple components"))
+		log.Fatal("Could not calculate principal components")
 	}
 
 	// Sum the eignvalues (variances).
@@ -94,7 +94,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	p.X.Label.Text = "Principle components"
+	p.X.Label.Text = "Principal components"
 	p.Y.Label.Text = "Percent of variance captured"
 	p.Y.Max = 110.0
 	p.X.Max = 3.1

--- a/topics/data_science/dimensionality_reduction/example2/example2.go
+++ b/topics/data_science/dimensionality_reduction/example2/example2.go
@@ -27,14 +27,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../data/iris.csv")
+	f, err := os.Open("../data/iris.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 	reader.FieldsPerRecord = 5
 
 	// Read in all of the CSV records

--- a/topics/data_science/dimensionality_reduction/example2/example2.go
+++ b/topics/data_science/dimensionality_reduction/example2/example2.go
@@ -9,7 +9,6 @@ package main
 
 import (
 	"encoding/csv"
-	"fmt"
 	"image/color"
 	"log"
 	"os"
@@ -59,7 +58,7 @@ func main() {
 			// Convert the value to a float.
 			val, err := strconv.ParseFloat(record[i], 64)
 			if err != nil {
-				log.Fatal(fmt.Errorf("Could not parse float value"))
+				log.Fatal("Could not parse float value")
 			}
 
 			// Add the float value to the slice of floats.

--- a/topics/data_science/dimensionality_reduction/example2/example2.go
+++ b/topics/data_science/dimensionality_reduction/example2/example2.go
@@ -78,7 +78,7 @@ func main() {
 		log.Fatal("Could not calculate principal components")
 	}
 
-	// Sum the eignvalues (variances).
+	// Sum the eigenvalues (variances).
 	total := floats.Sum(vars)
 
 	// Calculate cumulative variance percentages for each sorted value.

--- a/topics/data_science/dimensionality_reduction/example3/example3.go
+++ b/topics/data_science/dimensionality_reduction/example3/example3.go
@@ -21,14 +21,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../data/iris.csv")
+	f, err := os.Open("../data/iris.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 	reader.FieldsPerRecord = 5
 
 	// Read in all of the CSV records

--- a/topics/data_science/dimensionality_reduction/example3/example3.go
+++ b/topics/data_science/dimensionality_reduction/example3/example3.go
@@ -53,7 +53,7 @@ func main() {
 			// Convert the value to a float.
 			val, err := strconv.ParseFloat(record[i], 64)
 			if err != nil {
-				log.Fatal(fmt.Errorf("Could not parse float value"))
+				log.Fatal("Could not parse float value")
 			}
 
 			// Add the float value to the slice of floats.

--- a/topics/data_science/dimensionality_reduction/example3/example3.go
+++ b/topics/data_science/dimensionality_reduction/example3/example3.go
@@ -4,7 +4,7 @@
 // go build
 // ./example3
 
-// Sample program to project iris data on to principle components.
+// Sample program to project iris data on to principal components.
 package main
 
 import (
@@ -69,7 +69,7 @@ func main() {
 	// and variances.
 	vecs, _, ok := stat.PrincipalComponents(mat, nil)
 	if !ok {
-		log.Fatal(fmt.Errorf("Could not calculate prinicple components"))
+		log.Fatal("Could not calculate principal components")
 	}
 
 	// Project the data onto the first 2 principal components.

--- a/topics/data_science/dimensionality_reduction/exercises/exercise1/exercise1.go
+++ b/topics/data_science/dimensionality_reduction/exercises/exercise1/exercise1.go
@@ -21,14 +21,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../../data/iris.csv")
+	f, err := os.Open("../../data/iris.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 	reader.FieldsPerRecord = 5
 
 	// Read in all of the CSV records

--- a/topics/data_science/dimensionality_reduction/exercises/exercise1/exercise1.go
+++ b/topics/data_science/dimensionality_reduction/exercises/exercise1/exercise1.go
@@ -4,7 +4,7 @@
 // go build
 // ./exercise1
 
-// Sample program to project iris data on to 3 principle components.
+// Sample program to project iris data on to 3 principal components.
 package main
 
 import (
@@ -69,7 +69,7 @@ func main() {
 	// and variances.
 	vecs, _, ok := stat.PrincipalComponents(mat, nil)
 	if !ok {
-		log.Fatal(fmt.Errorf("Could not calculate prinicple components"))
+		log.Fatal("Could not calculate prinicple components")
 	}
 
 	// Project the data onto the first 3 principal components.

--- a/topics/data_science/dimensionality_reduction/exercises/exercise1/exercise1.go
+++ b/topics/data_science/dimensionality_reduction/exercises/exercise1/exercise1.go
@@ -53,7 +53,7 @@ func main() {
 			// Convert the value to a float.
 			val, err := strconv.ParseFloat(record[i], 64)
 			if err != nil {
-				log.Fatal(fmt.Errorf("Could not parse float value"))
+				log.Fatal("Could not parse float value")
 			}
 
 			// Add the float value to the slice of floats.

--- a/topics/data_science/dimensionality_reduction/exercises/template1/template1.go
+++ b/topics/data_science/dimensionality_reduction/exercises/template1/template1.go
@@ -20,14 +20,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../../data/iris.csv")
+	f, err := os.Open("../../data/iris.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 	reader.FieldsPerRecord = 5
 
 	// Read in all of the CSV records

--- a/topics/data_science/dimensionality_reduction/exercises/template1/template1.go
+++ b/topics/data_science/dimensionality_reduction/exercises/template1/template1.go
@@ -4,7 +4,7 @@
 // go build
 // ./template1
 
-// Sample program to project iris data on to 3 principle components.
+// Sample program to project iris data on to 3 principal components.
 package main
 
 import (

--- a/topics/data_science/dimensionality_reduction/exercises/template1/template1.go
+++ b/topics/data_science/dimensionality_reduction/exercises/template1/template1.go
@@ -9,7 +9,6 @@ package main
 
 import (
 	"encoding/csv"
-	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -52,7 +51,7 @@ func main() {
 			// Convert the value to a float.
 			val, err := strconv.ParseFloat(record[i], 64)
 			if err != nil {
-				log.Fatal(fmt.Errorf("Could not parse float value"))
+				log.Fatal("Could not parse float value")
 			}
 
 			// Add the float value to the slice of floats.

--- a/topics/data_science/evaluation/README.md
+++ b/topics/data_science/evaluation/README.md
@@ -39,8 +39,8 @@ For the `labeled.csv` results, implement and calculate the evaluation metric cal
 
 For the `continuous.csv` results, implement and calculate the evaluation metric called "mean squared error" as defined [here](https://en.wikipedia.org/wiki/Mean_squared_error).  What advantages or disadvantages might this metric have as compared to mean absolute error?
 
-[Template](exercises/template1/template2.go) |
-[Answer](exercises/exercise1/exercise2.go)
+[Template](exercises/template2/template2.go) |
+[Answer](exercises/exercise2/exercise2.go)
 
 ___
 All material is licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).

--- a/topics/data_science/evaluation/example1/example1.go
+++ b/topics/data_science/evaluation/example1/example1.go
@@ -21,14 +21,14 @@ import (
 func main() {
 
 	// Open the continuous observations and predictions.
-	csvFile, err := os.Open("../data/continuous.csv")
+	f, err := os.Open("../data/continuous.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// observed and predicted will hold the parsed observed and predicted values
 	// form the continous data file.

--- a/topics/data_science/evaluation/example2/example2.go
+++ b/topics/data_science/evaluation/example2/example2.go
@@ -20,14 +20,14 @@ import (
 func main() {
 
 	// Open the continuous observations and predictions.
-	csvFile, err := os.Open("../data/continuous.csv")
+	f, err := os.Open("../data/continuous.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// observed and predicted will hold the parsed observed and predicted values
 	// form the continous data file.

--- a/topics/data_science/evaluation/example3/example3.go
+++ b/topics/data_science/evaluation/example3/example3.go
@@ -19,14 +19,14 @@ import (
 func main() {
 
 	// Open the binary observations and predictions.
-	csvFile, err := os.Open("../data/labeled.csv")
+	f, err := os.Open("../data/labeled.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// observed and predicted will hold the parsed observed and predicted values
 	// form the labeled data file.

--- a/topics/data_science/evaluation/example4/example4.go
+++ b/topics/data_science/evaluation/example4/example4.go
@@ -19,14 +19,14 @@ import (
 func main() {
 
 	// Open the labeled observations and predictions.
-	csvFile, err := os.Open("../data/labeled.csv")
+	f, err := os.Open("../data/labeled.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// observed and predicted will hold the parsed observed and predicted values
 	// form the labeled data file.

--- a/topics/data_science/evaluation/example5/example5.go
+++ b/topics/data_science/evaluation/example5/example5.go
@@ -19,14 +19,14 @@ import (
 func main() {
 
 	// Open the labeled observations and predictions.
-	csvFile, err := os.Open("../data/labeled.csv")
+	f, err := os.Open("../data/labeled.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// observed and predicted will hold the parsed observed and predicted values
 	// form the labeled data file.

--- a/topics/data_science/evaluation/exercises/exercise1/exercise1.go
+++ b/topics/data_science/evaluation/exercises/exercise1/exercise1.go
@@ -19,14 +19,14 @@ import (
 func main() {
 
 	// Open the labeled observations and predictions.
-	csvFile, err := os.Open("../../data/labeled.csv")
+	f, err := os.Open("../../data/labeled.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// observed and predicted will hold the parsed observed and predicted values
 	// form the labeled data file.

--- a/topics/data_science/evaluation/exercises/exercise2/exercise2.go
+++ b/topics/data_science/evaluation/exercises/exercise2/exercise2.go
@@ -20,14 +20,14 @@ import (
 func main() {
 
 	// Open the continuous observations and predictions.
-	csvFile, err := os.Open("../../data/continuous.csv")
+	f, err := os.Open("../../data/continuous.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// observed and predicted will hold the parsed observed and predicted values
 	// form the continous data file.

--- a/topics/data_science/evaluation/exercises/template1/template1.go
+++ b/topics/data_science/evaluation/exercises/template1/template1.go
@@ -19,14 +19,14 @@ import (
 func main() {
 
 	// Open the labeled observations and predictions.
-	csvFile, err := os.Open("../../data/labeled.csv")
+	f, err := os.Open("../../data/labeled.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// Read in the records looking for unexpected types in the columns.
 	var observed []int

--- a/topics/data_science/evaluation/exercises/template2/template2.go
+++ b/topics/data_science/evaluation/exercises/template2/template2.go
@@ -18,14 +18,14 @@ import (
 func main() {
 
 	// Open the continuous observations and predictions.
-	csvFile, err := os.Open("../../data/continuous.csv")
+	f, err := os.Open("../../data/continuous.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 
 	// Read in the records looking for unexpected types in the columns.
 	var observed []float64

--- a/topics/data_science/json/exercises/exercise1/exercise1.go
+++ b/topics/data_science/json/exercises/exercise1/exercise1.go
@@ -103,4 +103,9 @@ func main() {
 			log.Fatal(err)
 		}
 	}
+
+	// Make sure the output file is properly saved.
+	if err := tbl.Close(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/topics/data_science/matrices/example1/example1.go
+++ b/topics/data_science/matrices/example1/example1.go
@@ -21,14 +21,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../data/iris.csv")
+	f, err := os.Open("../data/iris.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 	reader.FieldsPerRecord = 5
 
 	// Read in all of the CSV records

--- a/topics/data_science/matrices/example1/example1.go
+++ b/topics/data_science/matrices/example1/example1.go
@@ -53,7 +53,7 @@ func main() {
 			// Convert the value to a float.
 			val, err := strconv.ParseFloat(record[i], 64)
 			if err != nil {
-				log.Fatal(fmt.Errorf("Could not parse float value"))
+				log.Fatal("Could not parse float value")
 			}
 
 			// Add the float value to the slice of floats.

--- a/topics/data_science/matrices/exercises/exercise1/exercise1.go
+++ b/topics/data_science/matrices/exercises/exercise1/exercise1.go
@@ -21,14 +21,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../../data/diabetes.csv")
+	f, err := os.Open("../../data/diabetes.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 	reader.FieldsPerRecord = 11
 
 	// Read in all of the CSV records

--- a/topics/data_science/matrices/exercises/exercise1/exercise1.go
+++ b/topics/data_science/matrices/exercises/exercise1/exercise1.go
@@ -53,7 +53,7 @@ func main() {
 			// Convert the value to a float.
 			val, err := strconv.ParseFloat(rawVal, 64)
 			if err != nil {
-				log.Fatal(fmt.Errorf("Could not parse float value"))
+				log.Fatal("Could not parse float value")
 			}
 
 			// Add the float value to the slice of floats.

--- a/topics/data_science/matrices/exercises/template1/template1.go
+++ b/topics/data_science/matrices/exercises/template1/template1.go
@@ -17,14 +17,14 @@ import (
 func main() {
 
 	// Open the iris dataset file.
-	csvFile, err := os.Open("../../data/diabetes.csv")
+	f, err := os.Open("../../data/diabetes.csv")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer csvFile.Close()
+	defer f.Close()
 
 	// Create a new CSV reader reading from the opened file.
-	reader := csv.NewReader(csvFile)
+	reader := csv.NewReader(f)
 	reader.FieldsPerRecord = 11
 
 	// Read in all of the CSV records

--- a/topics/data_science/matrix_operations/example3/example3.go
+++ b/topics/data_science/matrix_operations/example3/example3.go
@@ -4,7 +4,7 @@
 // go build
 // ./example3
 
-// Sample program to solve a eignvalue/vector problem.
+// Sample program to solve an eigenvalue/vector problem.
 package main
 
 import (

--- a/topics/data_science/matrix_operations/example3/example3.go
+++ b/topics/data_science/matrix_operations/example3/example3.go
@@ -22,7 +22,7 @@ func main() {
 	// Solve the eigenvalue problem.
 	var eig mat64.Eigen
 	if ok := eig.Factorize(a, true); !ok {
-		log.Fatal(fmt.Errorf("Could not factorize the EigenSym value."))
+		log.Fatal("Could not factorize the EigenSym value.")
 	}
 
 	// Output the eigenvalues.

--- a/topics/data_science/matrix_operations/exercises/exercise1/exercise1.go
+++ b/topics/data_science/matrix_operations/exercises/exercise1/exercise1.go
@@ -4,7 +4,7 @@
 // go build
 // ./exercise1
 
-// Sample program to divde a matrix by its norm.
+// Sample program to divide a matrix by its norm.
 package main
 
 import (

--- a/topics/data_science/matrix_operations/exercises/template1/template1.go
+++ b/topics/data_science/matrix_operations/exercises/template1/template1.go
@@ -4,7 +4,7 @@
 // go build
 // ./template1
 
-// Sample program to divde a matrix by its norm.
+// Sample program to divide a matrix by its norm.
 package main
 
 import "github.com/gonum/matrix/mat64"

--- a/topics/data_science/stats_measures/example3/example3.go
+++ b/topics/data_science/stats_measures/example3/example3.go
@@ -32,7 +32,7 @@ func main() {
 	// we will be looking at the measures for this variable.
 	floatCol, ok := irisDF.Col("sepal_length").Elements.(df.FloatElements)
 	if !ok {
-		log.Fatal(fmt.Errorf("Could not parse float column"))
+		log.Fatal("Could not parse float column")
 	}
 
 	// Convert the Gota float values to a normal slice of floats.

--- a/topics/data_science/stats_vizualization/example1/example1.go
+++ b/topics/data_science/stats_vizualization/example1/example1.go
@@ -58,7 +58,7 @@ func main() {
 	p.Add(h)
 
 	// Overlay The normal distribution function for comparison.
-	norm := plotter.NewFunction(distuv.UnitNormal.Prob)
+	norm := plotter.NewFunction(normDist.Prob)
 	norm.Color = color.RGBA{R: 255, A: 255}
 	norm.Width = vg.Points(2)
 	p.Add(norm)


### PR DESCRIPTION
- use more idiomatic file var names
- use backticks so no `"\"foo\""` needed
- make sure the `Close() error` is handled when writing files
- consistently spell out "principal components"
- typos (eigen, divide)
- don't needlessly create `error`s via `fmt.Errorf` together with `log.Fatal` (just use a `string`)
