### PR TITLE
Fix all tests under topics/web

### DIFF
--- a/courses/quick_tour/CONCURRENCY.md
+++ b/courses/quick_tour/CONCURRENCY.md
@@ -78,7 +78,7 @@ func main() {
 		// start a timer for this request
 		begin := time.Now()
 		
-		// Retreive the site
+		// Retrieve the site
 		if _, err := http.Get(site); err != nil {
 			fmt.Println(site, err)
 			continue
@@ -148,7 +148,7 @@ func main() {
 			
 			begin := time.Now()
 			
-			// Retreive the site
+			// Retrieve the site
 			if _, err := http.Get(site); err != nil {
 				fmt.Println(site, err)
 				continue

--- a/topics/web/apis/example2/main_test.go
+++ b/topics/web/apis/example2/main_test.go
@@ -28,7 +28,10 @@ func TestApp(t *testing.T) {
 	for _, tt := range tests {
 
 		// Setup a request for user api without thinking about version.
-		req := httptest.NewRequest("GET", ts.URL+"/api/users", nil)
+		req, err := http.NewRequest("GET", ts.URL+"/api/users", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Set the version header into the request.
 		req.Header.Set("x-version", tt.version)

--- a/topics/web/apis/example3/main.go
+++ b/topics/web/apis/example3/main.go
@@ -55,7 +55,7 @@ func showHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Retreive that customer from the DB.
+	// Retrieve that customer from the DB.
 	c, err := customer.Find(id)
 	if err != nil {
 		http.Error(res, err.Error(), http.StatusNotFound)

--- a/topics/web/apis/example4/main.go
+++ b/topics/web/apis/example4/main.go
@@ -10,10 +10,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/ardanlabs/gotraining/topics/web/customer"
 	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
 	"github.com/labstack/echo/middleware"
+
+	"github.com/ardanlabs/gotraining/topics/web/customer"
 )
 
 // App loads the entire API set together for use.
@@ -29,7 +29,7 @@ func App() http.Handler {
 	// context type in the request for later.
 	r.Use(func(h echo.HandlerFunc) echo.HandlerFunc {
 		return func(ctx echo.Context) error {
-			ctx.Request().Header().Set("Content-Type", "application/json")
+			ctx.Request().Header.Set("Content-Type", "application/json")
 			return h(ctx)
 		}
 	})
@@ -44,12 +44,7 @@ func App() http.Handler {
 		return ctx.Redirect(http.StatusMovedPermanently, "/customers")
 	})
 
-	// Create a standard echo server and bind
-	// the echo mux as the handler.
-	st := standard.New("")
-	st.SetHandler(r)
-
-	return st
+	return r
 }
 
 // indexHandler returns the entire list of customers in the DB.

--- a/topics/web/apis/example4/main.go
+++ b/topics/web/apis/example4/main.go
@@ -71,7 +71,7 @@ func showHandler(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	// Retreive that customer from the DB.
+	// Retrieve that customer from the DB.
 	c, err := customer.Find(id)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, err.Error())

--- a/topics/web/auth/example1/main_test.go
+++ b/topics/web/auth/example1/main_test.go
@@ -32,7 +32,10 @@ func TestIndexHandler(t *testing.T) {
 	for _, tt := range tests {
 
 		// Create a new request for the GET call.
-		req := httptest.NewRequest("GET", ts.URL, nil)
+		req, err := http.NewRequest("GET", ts.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Only apply the credentials if we have them.
 		if tt.Username != "" {

--- a/topics/web/consuming/example3/main_test.go
+++ b/topics/web/consuming/example3/main_test.go
@@ -36,7 +36,10 @@ func TestApp(t *testing.T) {
 	defer ts.Close()
 
 	// Create a new request for the PUT call.
-	req := httptest.NewRequest("PUT", ts.URL, nil)
+	req, err := http.NewRequest("PUT", ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Create a Client and perform the PUT call.
 	var client http.Client

--- a/topics/web/consuming/example5/main_test.go
+++ b/topics/web/consuming/example5/main_test.go
@@ -54,7 +54,10 @@ func TestApp(t *testing.T) {
 	defer ts.Close()
 
 	// Create a new request for the GET call.
-	req := httptest.NewRequest("GET", ts.URL, nil)
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Create a value of the custom transporter.
 	trans := customTransporter{

--- a/topics/web/consuming/example6/main_test.go
+++ b/topics/web/consuming/example6/main_test.go
@@ -30,7 +30,10 @@ func TestApp(t *testing.T) {
 	t.Run("without signature", func(st *testing.T) {
 
 		// Create a new request for the POST call with our payload.
-		req := httptest.NewRequest("POST", ts.URL, bytes.NewReader(payload))
+		req, err := http.NewRequest("POST", ts.URL, bytes.NewReader(payload))
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Create a Client and perform the POST call.
 		var client http.Client
@@ -58,7 +61,10 @@ func TestApp(t *testing.T) {
 		for _, tt := range table {
 
 			// Create a new request for the POST call with our payload.
-			req := httptest.NewRequest("POST", ts.URL, bytes.NewReader(payload))
+			req, err := http.NewRequest("POST", ts.URL, bytes.NewReader(payload))
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			// Create a Client using our custom transporter. Provide
 			// the shared secret.

--- a/topics/web/muxers/example3/main.go
+++ b/topics/web/muxers/example3/main.go
@@ -12,10 +12,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/ardanlabs/gotraining/topics/web/customer"
 	"github.com/labstack/echo"
-	"github.com/labstack/echo/engine/standard"
 	"github.com/labstack/echo/middleware"
+
+	"github.com/ardanlabs/gotraining/topics/web/customer"
 )
 
 // render contains a pointer to the templates.
@@ -38,7 +38,7 @@ func App() http.Handler {
 	r.Use(middleware.Logger())
 
 	// Load the customer templates.
-	r.SetRenderer(&render{customer.T})
+	r.Renderer = &render{customer.T}
 
 	// Define the routes and order matters.
 	r.GET("/customers/:id", showHandler)
@@ -47,12 +47,7 @@ func App() http.Handler {
 
 	r.GET("/", indexHandler)
 
-	// Create an echo server binding the
-	// echo router.
-	st := standard.New("")
-	st.SetHandler(r)
-
-	return st
+	return r
 }
 
 // indexHandler returns the entire list of customers in the DB.

--- a/topics/web/posts/example4/main_test.go
+++ b/topics/web/posts/example4/main_test.go
@@ -115,7 +115,10 @@ func testPost(ts *httptest.Server) func(*testing.T) {
 
 		// Create a POST request using the bytes buffer as
 		// the post data.
-		req := httptest.NewRequest("POST", ts.URL+"/upload", &bb)
+		req, err := http.NewRequest("POST", ts.URL+"/upload", &bb)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Set the content-type properly for this call.
 		req.Header.Set("Content-Type", writer.FormDataContentType())

--- a/topics/web/sessions_cookies/example1/main_test.go
+++ b/topics/web/sessions_cookies/example1/main_test.go
@@ -98,7 +98,10 @@ func testPostGet(ts *httptest.Server) func(*testing.T) {
 		}
 
 		// Set up a second GET request.
-		req := httptest.NewRequest("GET", ts.URL, nil)
+		req, err := http.NewRequest("GET", ts.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Copy the cookies over into the new request
 		// for the call.

--- a/topics/web/sessions_cookies/example2/main_test.go
+++ b/topics/web/sessions_cookies/example2/main_test.go
@@ -98,7 +98,10 @@ func testPostGet(ts *httptest.Server) func(*testing.T) {
 		}
 
 		// Set up a second GET request.
-		req := httptest.NewRequest("GET", ts.URL, nil)
+		req, err := http.NewRequest("GET", ts.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Copy the cookies over into the new request
 		// for the call.


### PR DESCRIPTION
Some code was broken because `github.com/labstack/echo` changed their API in a recent version. Those were updated.

Some other tests were broken in #171 because the `*http.Request` created by `httptest.NewRequest` is intended to mimic a server request. To make a client request you have to keep using `http.NewRequest`.