### PR TITLE
Control the order of elements in custom xml encoder

### DIFF
--- a/topics/web/serializers/example3/main.go
+++ b/topics/web/serializers/example3/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"encoding/xml"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -29,6 +30,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	fmt.Println()
 
 	// Create a user value for Mary Jane.
 	u := User{

--- a/topics/web/serializers/example4/main.go
+++ b/topics/web/serializers/example4/main.go
@@ -27,38 +27,10 @@ type User struct {
 // can dictate how the user is marshaled.
 func (u *User) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
-	// Call into MarshalText directly for the time value.
-	ca, err := u.CreatedAt.MarshalText()
-	if err != nil {
-		return err
-	}
-
-	// Create a document of key/value pairs for each field
-	m := map[string][]byte{
-		"first_name": []byte(u.FirstName),
-		"CreatedAt":  ca,
-		"Admin":      []byte(strconv.FormatBool(u.Admin)),
-		"Bio":        nil,
-	}
-
-	// Add the Bio value if we have one.
-	if u.Bio != nil {
-		m["Bio"] = []byte(*u.Bio)
-	}
-
-	// Omit the last name from the document unless
-	// we have a value.
-	if u.LastName != "" {
-		m["LastName"] = []byte(u.LastName)
-	}
-
-	// Create a slice of tokens starting with the element
-	// provided with the call.
-	tokens := []xml.Token{start}
-
-	// Range of the key/value pairs creating XML elements.
-	for key, value := range m {
-
+	// Create a slice of XML tokens for our document and a
+	// closure to add to it.
+	var tokens []xml.Token
+	addToken := func(key string, value []byte) {
 		// Declare the starting element.
 		se := xml.StartElement{
 			Name: xml.Name{
@@ -76,7 +48,36 @@ func (u *User) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		tokens = append(tokens, se, xml.CharData(value), ee)
 	}
 
-	// Append the final ending element with the slice.
+	// First append the starting token provided in the call to MarshalXML
+	// <User>
+	tokens = append(tokens, start)
+
+	// Add tokens for each piece of our User
+	addToken("first_name", []byte(u.FirstName))
+
+	// Omit the last name from the document unless we have a value.
+	if u.LastName != "" {
+		addToken("LastName", []byte(u.LastName))
+	}
+
+	addToken("Admin", []byte(strconv.FormatBool(u.Admin)))
+
+	// Add the Bio value if we have one. If not add an empty element.
+	var bio []byte
+	if u.Bio != nil {
+		bio = []byte(*u.Bio)
+	}
+	addToken("Bio", bio)
+
+	// Call into MarshalText directly for the time value.
+	ca, err := u.CreatedAt.MarshalText()
+	if err != nil {
+		return err
+	}
+	addToken("CreatedAt", ca)
+
+	// Finally append the ending element to match the start.
+	// </User>
 	tokens = append(tokens, xml.EndElement{Name: start.Name})
 
 	// Range over the tokens.

--- a/topics/web/serializers/example4/main_test.go
+++ b/topics/web/serializers/example4/main_test.go
@@ -26,22 +26,9 @@ func TestEncodeZeroValueUser(t *testing.T) {
 
 	// Validate we received the expected response.
 	got := strings.TrimSpace(bb.String())
-	want := []string{
-		`<User><first_name></first_name><CreatedAt>0001-01-01T00:00:00Z</CreatedAt><Admin>false</Admin><Bio></Bio></User>`,
-		`<User><Bio></Bio><first_name></first_name><CreatedAt>0001-01-01T00:00:00Z</CreatedAt><Admin>false</Admin></User>`,
-		`<User><Admin>false</Admin><Bio></Bio><first_name></first_name><CreatedAt>0001-01-01T00:00:00Z</CreatedAt></User>`,
-		`<User><CreatedAt>0001-01-01T00:00:00Z</CreatedAt><Admin>false</Admin><Bio></Bio><first_name></first_name></User>`,
-	}
+	want := `<User><first_name></first_name><Admin>false</Admin><Bio></Bio><CreatedAt>0001-01-01T00:00:00Z</CreatedAt></User>`
 
-	var found bool
-	for _, w := range want {
-		if got == w {
-			found = true
-			break
-		}
-	}
-
-	if !found {
+	if got != want {
 		t.Log("Wanted:", want)
 		t.Log("Got   :", got)
 		t.Fatal("Mismatch")
@@ -71,22 +58,9 @@ func TestEncodeUser(t *testing.T) {
 
 	// Validate we received the expected response.
 	got := strings.TrimSpace(bb.String())
-	want := []string{
-		`<User><first_name>Mary</first_name><CreatedAt>0001-01-01T00:00:00Z</CreatedAt><Admin>false</Admin><Bio>An Awesome Coder!</Bio><LastName>Jane</LastName></User>`,
-		`<User><Admin>false</Admin><Bio>An Awesome Coder!</Bio><LastName>Jane</LastName><first_name>Mary</first_name><CreatedAt>0001-01-01T00:00:00Z</CreatedAt></User>`,
-		`<User><CreatedAt>0001-01-01T00:00:00Z</CreatedAt><Admin>false</Admin><Bio>An Awesome Coder!</Bio><LastName>Jane</LastName><first_name>Mary</first_name></User>`,
-		`<User><Bio>An Awesome Coder!</Bio><LastName>Jane</LastName><first_name>Mary</first_name><CreatedAt>0001-01-01T00:00:00Z</CreatedAt><Admin>false</Admin></User>`,
-	}
+	want := `<User><first_name>Mary</first_name><LastName>Jane</LastName><Admin>false</Admin><Bio>An Awesome Coder!</Bio><CreatedAt>0001-01-01T00:00:00Z</CreatedAt></User>`
 
-	var found bool
-	for _, w := range want {
-		if got == w {
-			found = true
-			break
-		}
-	}
-
-	if !found {
+	if got != want {
 		t.Log("Wanted:", want)
 		t.Log("Got   :", got)
 		t.Fatal("Mismatch")


### PR DESCRIPTION
The test for `topics/web/serializers/example4` sometimes fails seemingly at random. I looked into it and it's because we build our custom xml encoder by ranging over a map which is not guaranteed to be in any particular order. Since we include five elements in our map there are possibly 120 combinations (though in reality I don't think we'd ever actually see all 120). The test code was looking for results in one of four combinations and most of the time that was good enough but sometimes it wasn't.

I would like to make the order of the elements deterministic. This PR includes one approach that uses a closure to append each element to the token slice and we just call it up to 5 times (no looping involved). I am willing to entertain other approaches if this code is not clear to students.