### PR TITLE
fix 'Courses' link in layout

### DIFF
--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -12,7 +12,7 @@
         </div>
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="/courses/README.md">Courses</a></li>
+            <li><a href="/topics/courses/README.md">Courses</a></li>
             <li><a href="http://ardanlabs.com">Ardan Labs</a></li>
             <li><a href="http://goinggo.net">GoingGo</a></li>
           </ul>

--- a/topics/courses/data/data_gathering/README.md
+++ b/topics/courses/data/data_gathering/README.md
@@ -4,23 +4,23 @@ This is material for developers who have some experience with Go and statistics 
 *Note: This material has been designed to be taught in a classroom environment. The code is well commented but missing some of the contextual concepts and ideas that will be covered in class.*
 
 #### CSV Data
-[Input/Output/Parsing](../../../topics/data/csv_io/README.md) | 
-[Cleaning/Organization](../../../topics/data/csv_cleaning/README.md)
+[Input/Output/Parsing](../../../data/csv_io/README.md) | 
+[Cleaning/Organization](../../../data/csv_cleaning/README.md)
 
 #### JSON Data
 
-[Marshalling/Unmarshalling](../../../topics/data/json/README.md)
+[Marshalling/Unmarshalling](../../../data/json/README.md)
 
 #### SQL-like Databases
 
-[Access/Querying/Modifications](../../../topics/data/sql/README.md)
+[Access/Querying/Modifications](../../../data/sql/README.md)
 
 #### Caching
 
-[Embedded/In-Memory Caching](../../../topics/data/caching/README.md)
+[Embedded/In-Memory Caching](../../../data/caching/README.md)
 
 #### Data Versioning
 
-[Data Versioning](../../../topics/data/data_versioning/README.md)
+[Data Versioning](../../../data/data_versioning/README.md)
 ___
 All material is licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).

--- a/topics/courses/data/introduction/README.md
+++ b/topics/courses/data/introduction/README.md
@@ -4,9 +4,9 @@ This is material for developers who have some experience with Go and statistics 
 *Note: This material has been designed to be taught in a classroom environment. The code is well commented but missing some of the contextual concepts and ideas that will be covered in class.*
 
 #### Introduction to Data Analysis
-[Data Analysis](../../../topics/data/data_analysis/README.md)
+[Data Analysis](../../../data/data_analysis/README.md)
 
 #### Maintaining Integrity in Data Analytics Applications
-[Integrity](../../../topics/data/integrity/README.md)   
+[Integrity](../../../data/integrity/README.md)   
 ___
 All material is licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).

--- a/topics/courses/data/matrices/README.md
+++ b/topics/courses/data/matrices/README.md
@@ -4,10 +4,10 @@ This is material for developers who have some experience with Go and statistics 
 *Note: This material has been designed to be taught in a classroom environment. The code is well commented but missing some of the contextual concepts and ideas that will be covered in class.*
 
 #### Matrix Creation/Modification/Access
-[Matrix Creation/Modification/Access](../../../topics/data/matrices/README.md) 
+[Matrix Creation/Modification/Access](../../../data/matrices/README.md) 
 
 #### Matrix Operations, Linear Algebra
-[Matrix Operations, Linear Algebra](../../../topics/data/matrix_operations/README.md) 
+[Matrix Operations, Linear Algebra](../../../data/matrix_operations/README.md) 
 
 ___
 All material is licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).

--- a/topics/courses/data/prediction/README.md
+++ b/topics/courses/data/prediction/README.md
@@ -4,17 +4,17 @@ This is material for developers who have some experience with Go and statistics 
 *Note: This material has been designed to be taught in a classroom environment. The code is well commented but missing some of the contextual concepts and ideas that will be covered in class.*
 
 #### Evalution and Validation
-[Evaluation](../../../topics/data/evaluation/README.md) | 
-[Validation](../../../topics/data/validation/README.md) 
+[Evaluation](../../../data/evaluation/README.md) | 
+[Validation](../../../data/validation/README.md) 
 
 #### Regression
 
-[Regression](../../../topics/data/regression/README.md) 
+[Regression](../../../data/regression/README.md) 
 
 #### Classification
 
-[k Nearest Neighbors](../../../topics/data/classification_kNN/README.md) | 
-[Decision Tree and Random Forest](../../../topics/data/classification_trees/README.md) 
+[k Nearest Neighbors](../../../data/classification_kNN/README.md) | 
+[Decision Tree and Random Forest](../../../data/classification_trees/README.md) 
 
 ___
 All material is licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).

--- a/topics/courses/data/statistics/README.md
+++ b/topics/courses/data/statistics/README.md
@@ -4,16 +4,16 @@ This is material for developers who have some experience with Go and statistics 
 *Note: This material has been designed to be taught in a classroom environment. The code is well commented but missing some of the contextual concepts and ideas that will be covered in class.*
 
 #### Summary Statistics and Visualization
-[Statistical Measures](../../../topics/data/stats_measures/README.md) | 
-[Visualizing Distributions](../../../topics/data/stats_visualization/README.md) 
+[Statistical Measures](../../../data/stats_measures/README.md) | 
+[Visualizing Distributions](../../../data/stats_visualization/README.md) 
 
 #### Dimensionality Reduction
 
-[Dimensionality Reduction](../../../topics/data/dimensionality_reduction/README.md)
+[Dimensionality Reduction](../../../data/dimensionality_reduction/README.md)
 
 #### Hypothesis Testing
 
-[Hypothesis Testing](../../../topics/data/hypothesis_testing/README.md)
+[Hypothesis Testing](../../../data/hypothesis_testing/README.md)
 
 ___
 All material is licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).

--- a/topics/courses/go/packages/README.md
+++ b/topics/courses/go/packages/README.md
@@ -18,8 +18,5 @@ This material covers the essential things you need to know about the standard li
 
 #### Reflection
 [Reflection](../../../go/packages/reflection/README.md)
-
-#### Command Line Interfaces
-[Command-Line Interface (CLI)](../../../go/cli/README.md)
 ___
 All material is licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
The "Courses" link in the header of the root page is broken. Just added 'topic' to the link path.