### PR TITLE
Revise web server shutdown examples

### DIFF
--- a/starter-kits/http/cmd/apid/main.go
+++ b/starter-kits/http/cmd/apid/main.go
@@ -43,7 +43,7 @@ func main() {
 	// Start listening for requests.
 	go func() {
 		log.Println("listener : Listening on " + host)
-		server.ListenAndServe()
+		log.Println("listener :", server.ListenAndServe())
 	}()
 
 	// Block until there's an interrupt then shut the server down. The main

--- a/starter-kits/http/cmd/apid/main.go
+++ b/starter-kits/http/cmd/apid/main.go
@@ -68,7 +68,7 @@ func blockUntilShutdown(server *http.Server) {
 	log.Println("shutdown : Attempting graceful shut down...")
 
 	// Create a context to attempt a graceful 5 second shutdown.
-	timeout := 5 * time.Second
+	const timeout = 5 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -78,7 +78,7 @@ func blockUntilShutdown(server *http.Server) {
 
 		// Looks like we timedout on the graceful shutdown. Kill it hard.
 		if err := server.Close(); err != nil {
-			log.Printf("shutdown : Errors killing server : %v", err)
+			log.Printf("shutdown : Error killing server : %v", err)
 		}
 	}
 }

--- a/topics/web/shutdown/example1/main.go
+++ b/topics/web/shutdown/example1/main.go
@@ -40,23 +40,22 @@ func main() {
 		MaxHeaderBytes: 1 << 20,
 	}
 
-	// Start listening for requests. We do this in a goroutine so our main func
-	// can be blocked waiting on the shutdown code.
+	// Start listening for requests.
 	go func() {
-		log.Println("listener : Started : Listening on :3000")
-		err := server.ListenAndServe()
-		log.Printf("listener : Completed : %v", err)
+		log.Println("listener : Listening on :3000")
+		log.Println("listener :", server.ListenAndServe())
 	}()
 
 	// Block until there's an interrupt then shut the server down. The main
 	// func must not return before this process is complete or in-flight
 	// requests will be aborted.
-	shutdownOnInterrupt(&server)
+	blockUntilShutdown(&server)
 
 	log.Println("main : Completed")
 }
 
-func shutdownOnInterrupt(server *http.Server) {
+// blockUntilShutdown holds the goroutine waiting for a signal to shutdown.
+func blockUntilShutdown(server *http.Server) {
 
 	// Set up channel to receive interrupt signals.
 	// We must use a buffered channel or risk missing the signal
@@ -65,24 +64,19 @@ func shutdownOnInterrupt(server *http.Server) {
 	signal.Notify(c, os.Interrupt)
 
 	// Block until a signal is received.
-	log.Println("shutdown : Waiting for a shutdown signal")
 	<-c
+	log.Println("shutdown : Attempting graceful shut down...")
 
-	log.Println("shutdown : Signal received. Attempting graceful shut down...")
-
-	// Create a context with a 5 second timeout. If the server can't
-	// gracefully shut down in that time we'll kill it.
+	// Create a context to attempt a graceful 5 second shutdown.
 	const timeout = 5 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// Try a graceful shutdown.
+	// Attempt the graceful shutdown.
 	if err := server.Shutdown(ctx); err != nil {
-
-		// Couldn't shut down gracefully. Try a forceful shutdown.
 		log.Printf("shutdown : Graceful shutdown did not complete in %v : %v", timeout, err)
-		log.Print("shutdown : Killing server.")
 
+		// Looks like we timedout on the graceful shutdown. Kill it hard.
 		if err := server.Close(); err != nil {
 			log.Printf("shutdown : Error killing server : %v", err)
 		}


### PR DESCRIPTION
- Set timeout as a const
- Change control flow of shutdown vs close
- Rename log messages from "closer" to "shutdown"