### PR TITLE
topics/web/serializers: Add an example showing common JSON mistakes

### DIFF
--- a/topics/web/serializers/README.md
+++ b/topics/web/serializers/README.md
@@ -2,16 +2,10 @@
 
 Learn the basics of using and applying custom JSON and XML serializers.
 
-## Notes
-
-* The standard library has much of what you need to build services and apps.
-* The http package provides the building blocks.
-* There are other great packages in the Go ecosystem to help.
-
 ## Links
 
-https://golang.org/pkg/net/http/  
-https://golang.org/doc/articles/wiki/  
+https://golang.org/pkg/encoding/json  
+https://golang.org/pkg/encoding/xml  
 
 ## Code Review
 
@@ -19,6 +13,7 @@ JSON Encoding: [Code](example1/main.go) | [Test](example1/main_test.go)
 MarshalJSON Interface: [Code](example2/main.go) | [Test](example2/main_test.go)  
 XML Encoding: [Code](example3/main.go) | [Test](example3/main_test.go)  
 MarshalXML Interface: [Code](example4/main.go) | [Test](example4/main_test.go)  
+JSON Mistakes: [Code](example5/main.go)  
 
 ## Exercises
 

--- a/topics/web/serializers/example5/main.go
+++ b/topics/web/serializers/example5/main.go
@@ -1,0 +1,64 @@
+// All material is licensed under the Apache License Version 2.0, January 2004
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Sample program to show common JSON mistakes.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+)
+
+// User represents a user in our system. email is not exported so it won't be
+// marshaled.
+type User struct {
+	Name  string   `json:"name"`
+	email string   `json:"email"`
+	Roles []string `json:"roles"`
+}
+
+func main() {
+
+	// Marshal a zero value User
+	b, err := json.Marshal(User{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	print("Zero value User", b)
+	print("Note 'roles' is null", nil)
+
+	// Initialize roles for an otherwise zeroed User
+	u := User{
+		Roles: []string{},
+	}
+
+	b, err = json.Marshal(u)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	print("User with empty roles slice", b)
+	print("Note 'roles' is [] not null", nil)
+
+	// Fill in data for user
+	u = User{
+		Name:  "Alice",
+		email: "alice@example.com",
+		Roles: []string{"admin", "agent"},
+	}
+
+	b, err = json.Marshal(u)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	print("User with data", b)
+
+	fmt.Println("\nNote in all examples 'email' is missing.")
+}
+
+func print(msg string, data []byte) {
+	fmt.Printf("%30s | %s\n", msg, string(data))
+}


### PR DESCRIPTION
I added an example to show two problems I see often when marshalling JSON

1. Attempting to marshal unexported fields
2. Marshalling a zero value (nil) slice. This isn't necessarily wrong but if you're serving this in a web API it is annoying for your clients to do a null check before accessing an array field. In JS for example if you try to check `.length` or iterate over a null value you'll get a TypeError at runtime.

