### PR TITLE
Use a Travis hosted instance of MongoDB for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+services:
+  - mongodb
+env:
+  - DB_HOST="127.0.0.1:27017"
 go:
   - tip
 

--- a/starter-kits/http/cmd/apid/tests/user_test.go
+++ b/starter-kits/http/cmd/apid/tests/user_test.go
@@ -197,7 +197,7 @@ func getUser400(t *testing.T) {
 
 			recv := w.Body.String()
 			resp := `{
-  "error": "bson.IsObjectIdHex: 12345: ID is not in it's proper form"
+  "error": "Id: 12345: bson.IsObjectIdHex: 12345: ID is not in it's proper form"
 }`
 			if resp != recv {
 				t.Log("Got :", recv)


### PR DESCRIPTION
With a little configuration we can ask Travis to launch a new MongoDB for each test run. This prevents false positives from leftover data in the Mlab instance.