### PR TITLE
topics/web: Bind servers to localhost and log launching

### DIFF
--- a/topics/web/apis/example1/main.go
+++ b/topics/web/apis/example1/main.go
@@ -60,5 +60,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/apis/example2/main.go
+++ b/topics/web/apis/example2/main.go
@@ -89,5 +89,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/apis/example3/main.go
+++ b/topics/web/apis/example3/main.go
@@ -104,5 +104,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/apis/example4/main.go
+++ b/topics/web/apis/example4/main.go
@@ -103,5 +103,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/auth/example1/main.go
+++ b/topics/web/auth/example1/main.go
@@ -51,5 +51,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/auth/example2/main.go
+++ b/topics/web/auth/example2/main.go
@@ -106,5 +106,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/auth/example3/main.go
+++ b/topics/web/auth/example3/main.go
@@ -119,5 +119,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/basics/example1/main.go
+++ b/topics/web/basics/example1/main.go
@@ -21,6 +21,11 @@ func main() {
 	http.HandleFunc("/", f)
 
 	// Start the http server to handle the request.
+	// You provide the host:port to bind to. Here we are binding to port 300 only
+	// on the local network by specifying "localhost:3000". If you want this
+	// service to hear connections from external machines you can omit the host
+	// and just do ":3000".
+	// It's also a good idea to log that the server is starting.
 	log.Print("Listening on localhost:3000")
 	log.Panic(http.ListenAndServe("localhost:3000", nil))
 }

--- a/topics/web/basics/example1/main.go
+++ b/topics/web/basics/example1/main.go
@@ -21,5 +21,6 @@ func main() {
 	http.HandleFunc("/", f)
 
 	// Start the http server to handle the request.
-	log.Panic(http.ListenAndServe(":3000", nil))
+	log.Print("Listening on localhost:3000")
+	log.Panic(http.ListenAndServe("localhost:3000", nil))
 }

--- a/topics/web/basics/example2/main.go
+++ b/topics/web/basics/example2/main.go
@@ -28,5 +28,6 @@ func main() {
 	m.HandleFunc("/foo", f)
 
 	// Start the http server to handle the request.
-	log.Panic(http.ListenAndServe(":3000", m))
+	log.Print("Listening on localhost:3000")
+	log.Panic(http.ListenAndServe("localhost:3000", m))
 }

--- a/topics/web/basics/example3/main.go
+++ b/topics/web/basics/example3/main.go
@@ -22,5 +22,6 @@ func main() {
 
 	// Start the http server to handle the requests using
 	// our new Handler.
-	log.Panic(http.ListenAndServe(":3000", App{}))
+	log.Print("Listening on localhost:3000")
+	log.Panic(http.ListenAndServe("localhost:3000", App{}))
 }

--- a/topics/web/basics/example4/main.go
+++ b/topics/web/basics/example4/main.go
@@ -45,5 +45,6 @@ func main() {
 	m.Handle("/", wrap(myHandler))
 
 	// Start the http server to handle the request.
-	log.Panic(http.ListenAndServe(":3000", m))
+	log.Print("Listening on localhost:3000")
+	log.Panic(http.ListenAndServe("localhost:3000", m))
 }

--- a/topics/web/basics/example5/main.go
+++ b/topics/web/basics/example5/main.go
@@ -35,7 +35,8 @@ func main() {
 		})
 
 		// Start the http server to handle the request.
-		http.ListenAndServe(":3000", m)
+		log.Print("Listening on localhost:3000")
+		http.ListenAndServe("localhost:3000", m)
 	}()
 
 	// Get the current time so we can time how long this request takes.

--- a/topics/web/consuming/example6/main.go
+++ b/topics/web/consuming/example6/main.go
@@ -61,5 +61,6 @@ func App() http.Handler {
 func main() {
 
 	// Start the http server to handle requests
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/context/example1/main.go
+++ b/topics/web/context/example1/main.go
@@ -76,5 +76,6 @@ func App() http.Handler {
 func main() {
 
 	// Start the http server to handle requests.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/context/example2/main.go
+++ b/topics/web/context/example2/main.go
@@ -69,5 +69,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/middleware/example1/main.go
+++ b/topics/web/middleware/example1/main.go
@@ -70,5 +70,6 @@ func App() http.Handler {
 func main() {
 
 	// Start the http server to handle requests.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/middleware/example2/main.go
+++ b/topics/web/middleware/example2/main.go
@@ -70,5 +70,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/muxers/example1/main.go
+++ b/topics/web/muxers/example1/main.go
@@ -97,5 +97,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/muxers/example2/main.go
+++ b/topics/web/muxers/example2/main.go
@@ -97,5 +97,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/muxers/example3/main.go
+++ b/topics/web/muxers/example3/main.go
@@ -111,5 +111,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/posts/example1/main.go
+++ b/topics/web/posts/example1/main.go
@@ -50,5 +50,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/posts/example2/main.go
+++ b/topics/web/posts/example2/main.go
@@ -74,5 +74,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/posts/example3/main.go
+++ b/topics/web/posts/example3/main.go
@@ -84,5 +84,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/posts/example4/main.go
+++ b/topics/web/posts/example4/main.go
@@ -88,7 +88,8 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }
 
 // Returns the current directory we are running in.

--- a/topics/web/rest/example1/main.go
+++ b/topics/web/rest/example1/main.go
@@ -134,5 +134,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/sessions_cookies/example1/main.go
+++ b/topics/web/sessions_cookies/example1/main.go
@@ -103,5 +103,6 @@ func saveHandler(res http.ResponseWriter, req *http.Request) {
 func main() {
 
 	// Start the http server to handle requests
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/sessions_cookies/example2/main.go
+++ b/topics/web/sessions_cookies/example2/main.go
@@ -92,5 +92,6 @@ func main() {
 
 	// Start the http server to handle the request for
 	// both versions of the API.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/shutdown/example1/main.go
+++ b/topics/web/shutdown/example1/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	// Create a new server and set timeout values.
 	server := http.Server{
-		Addr:           ":3000",
+		Addr:           "localhost:3000",
 		Handler:        http.HandlerFunc(app),
 		ReadTimeout:    5 * time.Second,
 		WriteTimeout:   10 * time.Second,
@@ -47,7 +47,7 @@ func main() {
 
 	// Start the listener.
 	go func() {
-		log.Println("listener : Listening on :3000")
+		log.Println("listener : Listening on localhost:3000")
 		log.Println("listener :", server.ListenAndServe())
 		wg.Done()
 	}()

--- a/topics/web/sockets/example1/main.go
+++ b/topics/web/sockets/example1/main.go
@@ -92,5 +92,6 @@ func currentDirectory() string {
 func main() {
 
 	// Start the http server to handle requests.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/sockets/example2/main.go
+++ b/topics/web/sockets/example2/main.go
@@ -106,5 +106,6 @@ func currentDirectory() string {
 func main() {
 
 	// Start the http server to handle requests.
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/templates/example7/main.go
+++ b/topics/web/templates/example7/main.go
@@ -41,5 +41,6 @@ func staticDir() string {
 func main() {
 
 	// Start the http server to serve our App
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/templates/example8/main.go
+++ b/topics/web/templates/example8/main.go
@@ -44,5 +44,6 @@ func App() http.Handler {
 func main() {
 
 	// Start the http server to serve our App
-	log.Fatal(http.ListenAndServe(":3000", App()))
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
 }

--- a/topics/web/tls/example1/main.go
+++ b/topics/web/tls/example1/main.go
@@ -17,8 +17,9 @@ func main() {
 		res.Write([]byte("Hello, world"))
 	})
 
-	//http.ListenAndServe(":3000", m)
-	err := http.ListenAndServeTLS(":3000", "cert.pem", "key.pem", m)
+	log.Print("Listening on localhost:3000")
+	//http.ListenAndServe("localhost:3000", m)
+	err := http.ListenAndServeTLS("localhost:3000", "cert.pem", "key.pem", m)
 	if err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
This PR does two things

First it adds a `log.Print` statement before we run `http.ListenAndServe`. This is just a good idea in general but specifically for our class it should help students get what's going on.

Second it changes `:3000` to `localhost:3000`. What we're currently doing binds to all available addresses but my change makes services only bind to the loopback interface. 

The benefit: Many students run a firewall on their machines which complains every time they launch a server binding to all addresses. By only binding to the loopback we avoid that annoyance.

The drawback: When the host is defined like this you might have problems deploying to production unless the service is deployed behind a load balance on the same machine. I added a note to `topics/web/basics/example1/main.go` to explain the difference.