### PR TITLE
Use buffered channels when listening for OS signals

### DIFF
--- a/starter-kits/http/cmd/apid/main.go
+++ b/starter-kits/http/cmd/apid/main.go
@@ -66,7 +66,7 @@ func main() {
 	}()
 
 	// Listen for an interrupt signal from the OS.
-	osSignals := make(chan os.Signal)
+	osSignals := make(chan os.Signal, 1)
 	signal.Notify(osSignals, os.Interrupt)
 
 	// Wait for a signal to shutdown.

--- a/topics/web/shutdown/example1/main.go
+++ b/topics/web/shutdown/example1/main.go
@@ -52,8 +52,9 @@ func main() {
 		wg.Done()
 	}()
 
-	// Listen for an interrupt signal from the OS.
-	osSignals := make(chan os.Signal)
+	// Listen for an interrupt signal from the OS. Use a buffered
+	// channel because of how the signal package is implemented.
+	osSignals := make(chan os.Signal, 1)
 	signal.Notify(osSignals, os.Interrupt)
 
 	// Wait for a signal to shutdown.


### PR DESCRIPTION
The docs of signal.Notify say

	Package signal will not block sending to c: the caller must ensure
	that c has sufficient buffer space to keep up with the expected
	signal rate. For a channel used for notification of just one signal
	value, a buffer of size 1 is sufficient.

In the implementation of the signal package they're doing this

	// send but do not block for it
	select {
	case c <- sig:
	default:
	}