### PR TITLE
Add a more complete middleware example using Alice and gorilla/handlers

### DIFF
--- a/topics/web/middleware/README.md
+++ b/topics/web/middleware/README.md
@@ -13,12 +13,14 @@ Learn the basics of using and applying middleware.
 https://golang.org/pkg/net/http/  
 https://golang.org/doc/articles/wiki/  
 github.com/urfave/negroni  
+github.com/justinas/alice  
 github.com/gorilla/handlers  
 
 ## Code Review
 
 Basic middleware: [Code](example1/main.go) | [Test](example1/main_test.go)  
 Negroni router: [Code](example2/main.go) | [Test](example2/main_test.go)  
+Alice with Gorilla Handlers: [Code](example3/main.go)  
 
 ## Exercises
 

--- a/topics/web/middleware/example3/handlers.go
+++ b/topics/web/middleware/example3/handlers.go
@@ -1,0 +1,14 @@
+package main
+
+import "net/http"
+
+// helloWorld is one of our application handlers. It greets the world.
+func helloWorld(res http.ResponseWriter, req *http.Request) {
+	res.Write([]byte("Hello World"))
+}
+
+// secret is a handler which reveals a secret phrase. It should be
+// behind a middleware that ensures we don't just give it out freely.
+func secret(res http.ResponseWriter, req *http.Request) {
+	res.Write([]byte("Be sure to drink your Ovaltine!"))
+}

--- a/topics/web/middleware/example3/main.go
+++ b/topics/web/middleware/example3/main.go
@@ -1,0 +1,46 @@
+// All material is licensed under the Apache License Version 2.0, January 2004
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Sample program to show how to apply middleware using negroni.
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/handlers"
+	"github.com/justinas/alice"
+)
+
+// App loads the API and the middleware.
+func App() http.Handler {
+
+	// Create a middleware chain of useful gorilla handlers
+	chain := alice.New(
+		logger,                             // An adapter to use the gorilla logger
+		fooHeader,                          // A custom middleware
+		handlers.RecoveryHandler(),         // Serve 500 status on panics
+		handlers.CompressHandler,           // Gzip responses
+		handlers.ProxyHeaders,              // Interpret headers from reverse proxy like nginx
+		handlers.HTTPMethodOverrideHandler, // Support PUT/DELETE for some older clients
+		handlers.CORS(),                    // Allow cross origin requests
+	)
+
+	// A second chain that is only used for certain "secured" routes
+	secure := alice.New(decoderCheck)
+
+	// Create a mux and bind our handlers to routes. The default route
+	// does not use any special middleware. The /secret route uses the
+	// additional "secure" middleware chain.
+	m := http.NewServeMux()
+	m.HandleFunc("/", helloWorld)
+	m.Handle("/secret", secure.ThenFunc(secret))
+
+	// Wrap the chain around our mux. All requests use this chain first.
+	return chain.Then(m)
+}
+
+func main() {
+	log.Print("Listening on localhost:3000")
+	log.Fatal(http.ListenAndServe("localhost:3000", App()))
+}

--- a/topics/web/middleware/example3/mw.go
+++ b/topics/web/middleware/example3/mw.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/gorilla/handlers"
+)
+
+// logger is a middleware that wraps the logger from gorilla/handlers
+func logger(h http.Handler) http.Handler {
+	return handlers.LoggingHandler(os.Stdout, h)
+}
+
+// fooHeader returns a handler function that will set the `foo` header
+// key then call the next handler.
+func fooHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Set("foo", "bar")
+
+		next.ServeHTTP(res, req)
+	})
+}
+
+// decoderCheck is a middleware that looks for a secret value in a
+// request header. If it is not present then it will reject requests.
+// A better solution is introduced in the topics/web/auth section.
+func decoderCheck(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("X-Decoder-Ring") != "Little Orphan Annie" {
+			res.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		next.ServeHTTP(res, req)
+	})
+}


### PR DESCRIPTION
The other middleware examples introduce the concepts but this example is intended to be more "complete" in showing more of how I would actually write something using middleware. It also introduces two very useful community packages: 

- `github.com/justinas/alice` which is a super lightweight way of chaining MW
- `github.com/gorilla/handlers` which is a collection of very useful and commonly needed middleware such as logging requests in the Apache log format, handling panic, gzipping responses, activating CORS, etc.

This example also shows how to have additional middleware run for certain routes which is a common question when I get to this section.