### PR TITLE
topics/data: Move most gonum imports to new path

### DIFF
--- a/topics/data/classification_kNN/example1/example1.go
+++ b/topics/data/classification_kNN/example1/example1.go
@@ -12,12 +12,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/floats"
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/vg"
-	"github.com/gonum/stat"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/stat"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/classification_trees/exercises/exercise1/exercise1.go
+++ b/topics/data/classification_trees/exercises/exercise1/exercise1.go
@@ -15,13 +15,13 @@ import (
 	"math/rand"
 	"os"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/plotutil"
-	"github.com/gonum/plot/vg"
 	"github.com/sjwhitworth/golearn/base"
 	"github.com/sjwhitworth/golearn/evaluation"
 	"github.com/sjwhitworth/golearn/trees"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/plotutil"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/classification_trees/exercises/template1/template1.go
+++ b/topics/data/classification_trees/exercises/template1/template1.go
@@ -14,9 +14,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/vg"
 	"github.com/sjwhitworth/golearn/base"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/dimensionality_reduction/README.md
+++ b/topics/data/dimensionality_reduction/README.md
@@ -20,7 +20,7 @@ Data scientists use dimensionality reduction to transfrom high-dimensional data 
 
 ## Code Review
 
-[github.com/gonum/stat docs](https://godoc.org/github.com/gonum/stat)    
+[gonum.org/v1/gonum/stat docs](https://godoc.org/gonum.org/v1/gonum/stat)    
 [Calculate Principal Components](example1/example1.go)      
 [Determine a Number of Target Dimensions](example2/example2.go)       
 [Project the Data](example3/example3.go)  

--- a/topics/data/dimensionality_reduction/example1/example1.go
+++ b/topics/data/dimensionality_reduction/example1/example1.go
@@ -12,8 +12,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/stat"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/gonum/stat"
 )
 
 func main() {

--- a/topics/data/dimensionality_reduction/example2/example2.go
+++ b/topics/data/dimensionality_reduction/example2/example2.go
@@ -12,14 +12,16 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/floats"
+	// These use the deprecated import because of a dependency on mat64 in gota
 	"github.com/gonum/matrix/mat64"
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/plotutil"
-	"github.com/gonum/plot/vg"
 	"github.com/gonum/stat"
 	"github.com/kniren/gota/dataframe"
+
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/plotutil"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/dimensionality_reduction/example3/example3.go
+++ b/topics/data/dimensionality_reduction/example3/example3.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"os"
 
+	// These use the deprecated import because of a dependency on mat64 in gota
 	"github.com/gonum/matrix/mat64"
 	"github.com/gonum/stat"
 	"github.com/kniren/gota/dataframe"

--- a/topics/data/dimensionality_reduction/exercises/exercise1/exercise1.go
+++ b/topics/data/dimensionality_reduction/exercises/exercise1/exercise1.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"os"
 
+	// These use the deprecated import because of a dependency on mat64 in gota
 	"github.com/gonum/matrix/mat64"
 	"github.com/gonum/stat"
 	"github.com/kniren/gota/dataframe"

--- a/topics/data/evaluation/example1/example1.go
+++ b/topics/data/evaluation/example1/example1.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/gonum/stat"
+	"gonum.org/v1/gonum/stat"
 )
 
 func main() {

--- a/topics/data/matrices/README.md
+++ b/topics/data/matrices/README.md
@@ -6,7 +6,7 @@ Many modeling, machine learning, and optimization algorithms rely on linear alge
 
 - A matrix is a rectangular array representation of numbers, expressions, etc.
 - Elements in a matrix are referenced by a row and column index.
-- `github.com/gonum/matrix/mat64` provides functionality to create, modify, and manipulate matrices made up of float64 values.
+- `gonum.org/v1/gonum/mat` provides functionality to create, modify, and manipulate matrices made up of float64 values.
 
 ## Links
 
@@ -16,7 +16,7 @@ Many modeling, machine learning, and optimization algorithms rely on linear alge
 
 ## Code Review
 
-[github/gonum/matrix/mat64 docs](https://godoc.org/github.com/gonum/matrix/mat64)    
+[gonum.org/v1/mat docs](https://godoc.org/gonum.org/v1/gonum/mat)    
 [Form a float64 matrix](example1/example1.go)  
 [Modify a matrix](example2/example2.go)  
 [Access values in a matrix](example3/example3.go)  
@@ -26,7 +26,7 @@ Many modeling, machine learning, and optimization algorithms rely on linear alge
 
 ### Exercise 1
 
-Create a matrix from [diabetes.csv](../data_versioning/data/diabetes.csv) using `github.com/gonum/matrix/mat64`. Format and output the first 10 rows to standard out.
+Create a matrix from [diabetes.csv](../data_versioning/data/diabetes.csv) using `gonum.org/v1/gonum/mat`. Format and output the first 10 rows to standard out.
 
 [Template](exercises/template1/template1.go) |
 [Answer](exercises/exercise1/exercise1.go)

--- a/topics/data/matrices/example1/example1.go
+++ b/topics/data/matrices/example1/example1.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/gonum/matrix/mat64"
+	"gonum.org/v1/gonum/mat"
 )
 
 func main() {
@@ -68,9 +68,9 @@ func main() {
 	}
 
 	// Form the matrix.
-	mat := mat64.NewDense(len(rawCSVData), 4, floatData)
+	m := mat.NewDense(len(rawCSVData), 4, floatData)
 
 	// As a sanity check, output the matrix to standard out.
-	fMat := mat64.Formatted(mat, mat64.Prefix("      "))
+	fMat := mat.Formatted(m, mat.Prefix("      "))
 	fmt.Printf("mat = %v\n\n", fMat)
 }

--- a/topics/data/matrices/example2/example2.go
+++ b/topics/data/matrices/example2/example2.go
@@ -10,13 +10,13 @@ package main
 import (
 	"fmt"
 
-	"github.com/gonum/matrix/mat64"
+	"gonum.org/v1/gonum/mat"
 )
 
 func main() {
 
 	// Create a small matrix.
-	a := mat64.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
+	a := mat.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
 
 	// Modify a single element.
 	a.Set(0, 2, 0)
@@ -28,6 +28,6 @@ func main() {
 	a.SetCol(0, []float64{1.0, 3.0, 2.0})
 
 	// Print it again without zero value elements.
-	fa := mat64.Formatted(a, mat64.Prefix("    "))
+	fa := mat.Formatted(a, mat.Prefix("    "))
 	fmt.Printf("after modification:\na = % v\n\n", fa)
 }

--- a/topics/data/matrices/example3/example3.go
+++ b/topics/data/matrices/example3/example3.go
@@ -10,24 +10,24 @@ package main
 import (
 	"fmt"
 
-	"github.com/gonum/matrix/mat64"
+	"gonum.org/v1/gonum/mat"
 )
 
 func main() {
 
 	// Create a small matrix.
-	a := mat64.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
+	a := mat.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
 
 	// Get a single value from the matrix.
 	val := a.At(0, 1)
 	fmt.Printf("The value of a at (0,1) is: %.2f\n\n", val)
 
 	// Get the values in a specific column.
-	col := mat64.Col(nil, 2, a)
+	col := mat.Col(nil, 2, a)
 	fmt.Printf("The values in the 3rd column are: %v\n\n", col)
 
 	// Get the values in a specific row.
-	row := mat64.Row(nil, 2, a)
+	row := mat.Row(nil, 2, a)
 	fmt.Printf("The values in the 3rd row are: %v\n\n", row)
 
 	// Get a "view" of a portion of the matrix extending from a starting
@@ -36,6 +36,6 @@ func main() {
 	b := a.View(0, 0, 2, 2)
 
 	// Print it again without zero value elements.
-	fb := mat64.Formatted(b, mat64.Prefix("    "))
+	fb := mat.Formatted(b, mat.Prefix("    "))
 	fmt.Printf("The \"view\" of a looks like:\nb = % v\n\n", fb)
 }

--- a/topics/data/matrices/example4/example4.go
+++ b/topics/data/matrices/example4/example4.go
@@ -10,16 +10,16 @@ package main
 import (
 	"fmt"
 
-	"github.com/gonum/matrix/mat64"
+	"gonum.org/v1/gonum/mat"
 )
 
 func main() {
 
 	// Create a small matrix.
-	a := mat64.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
+	a := mat.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
 
 	// Create a matrix formatting value with a prefix.
-	fa := mat64.Formatted(a, mat64.Prefix("    "))
+	fa := mat.Formatted(a, mat.Prefix("    "))
 
 	// Print the matrix with and without zero value elements.
 	fmt.Printf("with all values:\na = %v\n\n", fa)

--- a/topics/data/matrices/exercises/exercise1/exercise1.go
+++ b/topics/data/matrices/exercises/exercise1/exercise1.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/gonum/matrix/mat64"
+	"gonum.org/v1/gonum/mat"
 )
 
 func main() {
@@ -63,12 +63,12 @@ func main() {
 	}
 
 	// Form the matrix.
-	mat := mat64.NewDense(len(rawCSVData), 11, floatData)
+	m := mat.NewDense(len(rawCSVData), 11, floatData)
 
 	// Get the first 10 rows.
-	firstTen := mat.View(0, 0, 10, 11)
+	firstTen := m.Slice(0, 10, 0, 11)
 
 	// As a sanity check, output the rows to standard out.
-	fMat := mat64.Formatted(firstTen, mat64.Prefix("      "))
-	fmt.Printf("mat = %v\n\n", fMat)
+	fMat := mat.Formatted(firstTen, mat.Prefix("    "))
+	fmt.Printf("m = %v\n\n", fMat)
 }

--- a/topics/data/matrix_operations/README.md
+++ b/topics/data/matrix_operations/README.md
@@ -11,7 +11,7 @@ As mentioned, matrix operations are ubiquitous in the data science world.  Most 
 
 ## Links
 
-[github/gonum/matrix/mat64 docs](https://godoc.org/github.com/gonum/matrix/mat64)  
+[gonum.org/v1/gonum/mat docs](https://godoc.org/gonum.org/v1/gonum/mat)  
 [The Matrix Cookbook](http://www.math.uwaterloo.ca/~hwolkowi/matrixcookbook.pdf)  
 [Khan Academy - Matrices](https://www.khanacademy.org/math/algebra-home/precalculus/precalc-matrices)  
 [Khan Academy - Linear Algebra](https://www.khanacademy.org/math/linear-algebra)   

--- a/topics/data/matrix_operations/example1/example1.go
+++ b/topics/data/matrix_operations/example1/example1.go
@@ -11,46 +11,46 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/gonum/matrix/mat64"
+	"gonum.org/v1/gonum/mat"
 )
 
 func main() {
 
 	// Create two matrices of the same size, a and b.
-	a := mat64.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
-	b := mat64.NewDense(3, 3, []float64{8, 9, 10, 1, 4, 2, 9, 0, 2})
+	a := mat.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
+	b := mat.NewDense(3, 3, []float64{8, 9, 10, 1, 4, 2, 9, 0, 2})
 
 	// Create a third matrix of a different size.
-	c := mat64.NewDense(3, 2, []float64{3, 2, 1, 4, 0, 8})
+	c := mat.NewDense(3, 2, []float64{3, 2, 1, 4, 0, 8})
 
 	// Send the original matrices to standard out.
-	fa := mat64.Formatted(a, mat64.Prefix("    "))
-	fb := mat64.Formatted(b, mat64.Prefix("    "))
+	fa := mat.Formatted(a, mat.Prefix("    "))
+	fb := mat.Formatted(b, mat.Prefix("    "))
 	fmt.Printf("\na = %0.4v\n\n", fa)
 	fmt.Printf("b = %0.4v\n\n", fb)
 
 	// Add a and b.
-	d := mat64.NewDense(0, 0, nil)
+	d := mat.NewDense(0, 0, nil)
 	d.Add(a, b)
-	fd := mat64.Formatted(d, mat64.Prefix("            "))
+	fd := mat.Formatted(d, mat.Prefix("            "))
 	fmt.Printf("d = a + b = %0.4v\n\n", fd)
 
 	// Multiply a and c.
-	f := mat64.NewDense(0, 0, nil)
+	f := mat.NewDense(0, 0, nil)
 	f.Mul(a, c)
-	ff := mat64.Formatted(f, mat64.Prefix("          "))
+	ff := mat.Formatted(f, mat.Prefix("          "))
 	fmt.Printf("f = a c = %0.4v\n\n", ff)
 
 	// Raising a matrix to a power.
-	g := mat64.NewDense(0, 0, nil)
+	g := mat.NewDense(0, 0, nil)
 	g.Pow(a, 5)
-	fg := mat64.Formatted(g, mat64.Prefix("          "))
+	fg := mat.Formatted(g, mat.Prefix("          "))
 	fmt.Printf("g = a^5 = %0.4v\n\n", fg)
 
 	// Apply a function to each of the elements of a.
-	h := mat64.NewDense(0, 0, nil)
+	h := mat.NewDense(0, 0, nil)
 	sqrt := func(_, _ int, v float64) float64 { return math.Sqrt(v) }
 	h.Apply(sqrt, a)
-	fh := mat64.Formatted(h, mat64.Prefix("              "))
+	fh := mat.Formatted(h, mat.Prefix("              "))
 	fmt.Printf("h = sqrt(a) = %0.4v\n\n", fh)
 }

--- a/topics/data/matrix_operations/example2/example2.go
+++ b/topics/data/matrix_operations/example2/example2.go
@@ -12,27 +12,27 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/gonum/matrix/mat64"
+	"gonum.org/v1/gonum/mat"
 )
 
 func main() {
 
 	// Create two matrices of the same size, a and b.
-	a := mat64.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
+	a := mat.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
 
 	// Compute and output the transpose of the matrix.
-	ft := mat64.Formatted(a.T(), mat64.Prefix("      "))
+	ft := mat.Formatted(a.T(), mat.Prefix("      "))
 	fmt.Printf("a^T = %v\n\n", ft)
 
 	// Compute and output the determinant of a.
-	deta := mat64.Det(a)
+	deta := mat.Det(a)
 	fmt.Printf("det(a) = %.2f\n\n", deta)
 
 	// Compute and output the inverse of a.
-	aInverse := mat64.NewDense(0, 0, nil)
+	aInverse := mat.NewDense(0, 0, nil)
 	if err := aInverse.Inverse(a); err != nil {
 		log.Fatal(err)
 	}
-	fi := mat64.Formatted(aInverse, mat64.Prefix("       "))
+	fi := mat.Formatted(aInverse, mat.Prefix("       "))
 	fmt.Printf("a^-1 = %v\n\n", fi)
 }

--- a/topics/data/matrix_operations/example3/example3.go
+++ b/topics/data/matrix_operations/example3/example3.go
@@ -11,16 +11,16 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/gonum/matrix/mat64"
+	"gonum.org/v1/gonum/mat"
 )
 
 func main() {
 
 	// Create two matrices of the same size, a and b.
-	a := mat64.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
+	a := mat.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
 
 	// Solve the eigenvalue problem.
-	var eig mat64.Eigen
+	var eig mat.Eigen
 	if ok := eig.Factorize(a, false, true); !ok {
 		log.Fatal("Could not factorize the EigenSym value.")
 	}
@@ -30,6 +30,6 @@ func main() {
 
 	// Output the eigenvectors.
 	vectors := eig.Vectors()
-	fv := mat64.Formatted(vectors, mat64.Prefix("               "))
+	fv := mat.Formatted(vectors, mat.Prefix("               "))
 	fmt.Printf("eigenvectors = %v\n\n", fv)
 }

--- a/topics/data/matrix_operations/example4/example4.go
+++ b/topics/data/matrix_operations/example4/example4.go
@@ -10,8 +10,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/gonum/floats"
-	"github.com/gonum/matrix/mat64"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/mat"
 )
 
 func main() {
@@ -24,10 +24,10 @@ func main() {
 	fmt.Printf("\nThe Vector norm of vec is: %0.2f\n\n", vecNorm)
 
 	// Create an example matrix.
-	mat := mat64.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
+	m := mat.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
 
 	// Get the Euclidean norm of the matrix.
-	matNorm := mat64.Norm(mat, 2)
+	matNorm := mat.Norm(m, 2)
 	fmt.Printf("The Matrix norm of mat is: %0.2f\n\n", matNorm)
 
 }

--- a/topics/data/matrix_operations/exercises/exercise1/exercise1.go
+++ b/topics/data/matrix_operations/exercises/exercise1/exercise1.go
@@ -10,22 +10,22 @@ package main
 import (
 	"fmt"
 
-	"github.com/gonum/matrix/mat64"
+	"gonum.org/v1/gonum/mat"
 )
 
 func main() {
 
 	// Create an example matrix.
-	mat := mat64.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
+	m := mat.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
 
 	// Get the Euclidean norm of the matrix.
-	matNorm := mat64.Norm(mat, 2)
+	matNorm := mat.Norm(m, 2)
 
 	// Multiply the matrix by 1 / matNorm.
-	matScaled := mat64.NewDense(0, 0, nil)
-	matScaled.Scale(1/matNorm, mat)
+	matScaled := mat.NewDense(0, 0, nil)
+	matScaled.Scale(1/matNorm, m)
 
 	// Output the matrix to standard out.
-	ft := mat64.Formatted(matScaled, mat64.Prefix("         "))
+	ft := mat.Formatted(matScaled, mat.Prefix("         "))
 	fmt.Printf("a/norm = %v\n\n", ft)
 }

--- a/topics/data/matrix_operations/exercises/template1/template1.go
+++ b/topics/data/matrix_operations/exercises/template1/template1.go
@@ -7,12 +7,12 @@
 // Sample program to divide a matrix by its norm.
 package main
 
-import "github.com/gonum/matrix/mat64"
+import "gonum.org/v1/gonum/mat"
 
 func main() {
 
 	// Create an example matrix.
-	mat := mat64.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
+	m := mat.NewDense(3, 3, []float64{1, 2, 3, 0, 4, 5, 0, 0, 6})
 
 	// Get the Euclidean norm of the matrix.
 

--- a/topics/data/regression/example1/example1.go
+++ b/topics/data/regression/example1/example1.go
@@ -12,12 +12,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/floats"
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/vg"
-	"github.com/gonum/stat"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/stat"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/regression/example2/example2.go
+++ b/topics/data/regression/example2/example2.go
@@ -12,10 +12,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/vg"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/stats_measures/README.md
+++ b/topics/data/stats_measures/README.md
@@ -17,9 +17,9 @@ Despite a huge focus on machine learning in the context of data science, solid s
 
 ## Code Review
 
-[github.com/gonum/stat docs](https://godoc.org/github.com/gonum/stat)  
+[gonum.org/v1/gonum/stat docs](https://godoc.org/gonum.org/v1/gonum/stat)  
 [github.com/montanaflynn/stats docs](https://godoc.org/github.com/montanaflynn/stats)  
-[github.com/gonum/floats docs](https://godoc.org/github.com/gonum/floats)   
+[gonum.org/v1/gonum/floats docs](https://godoc.org/gonum.org/v1/gonum/floats)   
 [Mean, Mode, Median](example1/example1.go)  
 [Min, Max, Range](example2/example2.go)  
 [Variance, Standard Deviation](example3/example3.go)    

--- a/topics/data/stats_measures/example1/example1.go
+++ b/topics/data/stats_measures/example1/example1.go
@@ -12,9 +12,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/stat"
 	"github.com/kniren/gota/dataframe"
 	"github.com/montanaflynn/stats"
+	"gonum.org/v1/gonum/stat"
 )
 
 func main() {

--- a/topics/data/stats_measures/example2/example2.go
+++ b/topics/data/stats_measures/example2/example2.go
@@ -12,8 +12,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/floats"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/gonum/floats"
 )
 
 func main() {

--- a/topics/data/stats_measures/example3/example3.go
+++ b/topics/data/stats_measures/example3/example3.go
@@ -12,8 +12,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/stat"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/gonum/stat"
 )
 
 func main() {

--- a/topics/data/stats_measures/example4/example4.go
+++ b/topics/data/stats_measures/example4/example4.go
@@ -12,9 +12,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/floats"
-	"github.com/gonum/stat"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/stat"
 )
 
 func main() {

--- a/topics/data/stats_measures/exercises/exercise1/exercise1.go
+++ b/topics/data/stats_measures/exercises/exercise1/exercise1.go
@@ -13,9 +13,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/stat"
 	"github.com/kniren/gota/dataframe"
 	"github.com/montanaflynn/stats"
+	"gonum.org/v1/gonum/stat"
 )
 
 func main() {

--- a/topics/data/stats_visualization/README.md
+++ b/topics/data/stats_visualization/README.md
@@ -26,7 +26,7 @@ from [here](http://www.physics.csbsju.edu/stats/box2.html)
 
 ## Code Review
 
-[github.com/gonum/plot docs](https://godoc.org/github.com/gonum/plot)  
+[gonum.org/v1/plot docs](https://godoc.org/gonum.org/v1/plot)  
 [Histogram of a normal distribution](example1/example1.go)  
 [Histograms with real data](example2/example2.go)  
 [Box Plot with various distribution](example3/example3.go)  

--- a/topics/data/stats_visualization/example1/example1.go
+++ b/topics/data/stats_visualization/example1/example1.go
@@ -11,10 +11,10 @@ import (
 	"image/color"
 	"log"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/vg"
-	"github.com/gonum/stat/distuv"
+	"gonum.org/v1/gonum/stat/distuv"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/stats_visualization/example2/example2.go
+++ b/topics/data/stats_visualization/example2/example2.go
@@ -12,10 +12,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/vg"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/stats_visualization/example3/example3.go
+++ b/topics/data/stats_visualization/example3/example3.go
@@ -11,9 +11,9 @@ import (
 	"log"
 	"math/rand"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/vg"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/stats_visualization/example4/example4.go
+++ b/topics/data/stats_visualization/example4/example4.go
@@ -11,10 +11,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/vg"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/stats_visualization/exercises/exercise1/exercise1.go
+++ b/topics/data/stats_visualization/exercises/exercise1/exercise1.go
@@ -11,10 +11,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/vg"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/data/stats_visualization/exercises/exercise2/exercise2.go
+++ b/topics/data/stats_visualization/exercises/exercise2/exercise2.go
@@ -11,10 +11,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/vg"
 	"github.com/kniren/gota/dataframe"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
 )
 
 func main() {

--- a/topics/go/profiling/blocking/blocking_test.go
+++ b/topics/go/profiling/blocking/blocking_test.go
@@ -16,10 +16,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/plotutil"
-	"github.com/gonum/plot/vg"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/plotutil"
+	"gonum.org/v1/plot/vg"
 )
 
 // data represents a set of bytes to process.


### PR DESCRIPTION
The github.com/gonum imports have been deprecated in favor of their
gonum.org equivalents. I have updated most of the references but a few
of the mat64 examples still require the old version because of a
transitive dependency from the gota package. A comment has been added to
these where necessary.