### PR TITLE
Clarify some rune counting loops

### DIFF
--- a/topics/go/concurrency/goroutines/README.md
+++ b/topics/go/concurrency/goroutines/README.md
@@ -39,9 +39,9 @@ http://www.goinggo.net/2014/01/concurrency-goroutines-and-gomaxprocs.html
 
 ## Code Review
 
-[Goroutines and concurrency](example1/example1.go) ([Go Playground](https://play.golang.org/p/eV4l2JqLZL))  
+[Goroutines and concurrency](example1/example1.go) ([Go Playground](https://play.golang.org/p/OrouX37XR5))  
 [Goroutine time slicing](example2/example2.go) ([Go Playground](https://play.golang.org/p/8NwVeZG6IB))  
-[Goroutines and parallelism](example3/example3.go) ([Go Playground](https://play.golang.org/p/5A0VFp03vb))  
+[Goroutines and parallelism](example3/example3.go) ([Go Playground](https://play.golang.org/p/b0itBwIuUU))  
 
 ## Exercises
 

--- a/topics/go/concurrency/goroutines/example1/example1.go
+++ b/topics/go/concurrency/goroutines/example1/example1.go
@@ -49,8 +49,8 @@ func lowercase() {
 
 	// Display the alphabet three times
 	for count := 0; count < 3; count++ {
-		for rune := 'a'; rune < 'a'+26; rune++ {
-			fmt.Printf("%c ", rune)
+		for r := 'a'; r <= 'z'; r++ {
+			fmt.Printf("%c ", r)
 		}
 	}
 }
@@ -60,8 +60,8 @@ func uppercase() {
 
 	// Display the alphabet three times
 	for count := 0; count < 3; count++ {
-		for rune := 'A'; rune < 'A'+26; rune++ {
-			fmt.Printf("%c ", rune)
+		for r := 'A'; r <= 'Z'; r++ {
+			fmt.Printf("%c ", r)
 		}
 	}
 }

--- a/topics/go/concurrency/goroutines/example3/example3.go
+++ b/topics/go/concurrency/goroutines/example3/example3.go
@@ -31,8 +31,8 @@ func main() {
 
 		// Display the alphabet three times.
 		for count := 0; count < 3; count++ {
-			for rune := 'a'; rune < 'a'+26; rune++ {
-				fmt.Printf("%c ", rune)
+			for r := 'a'; r <= 'z'; r++ {
+				fmt.Printf("%c ", r)
 			}
 		}
 
@@ -45,8 +45,8 @@ func main() {
 
 		// Display the alphabet three times.
 		for count := 0; count < 3; count++ {
-			for rune := 'A'; rune < 'A'+26; rune++ {
-				fmt.Printf("%c ", rune)
+			for r := 'A'; r <= 'Z'; r++ {
+				fmt.Printf("%c ", r)
 			}
 		}
 


### PR DESCRIPTION
- Use `r` instead of `rune` for variable names. Using a type name as a variable name is a smell.
- `<= 'z'` seems more clear on intent than `< 'a'+26`