### PR TITLE
Show how to copy a slice without sharing a backing array

### DIFF
--- a/topics/go/language/slices/README.md
+++ b/topics/go/language/slices/README.md
@@ -23,18 +23,18 @@ https://github.com/golang/go/wiki/SliceTricks
 
 ## Code Review
 
-[Declare and Length](example1/example1.go) ([Go Playground](https://play.golang.org/p/lDKravTEqF))  
-[Reference Types](example2/example2.go) ([Go Playground](https://play.golang.org/p/MuqPFwvDux))  
-[Appending slices](example4/example4.go) ([Go Playground](https://play.golang.org/p/xiI54S0bSN))  
-[Taking slices of slices](example3/example3.go) ([Go Playground](https://play.golang.org/p/Wq9JbadHkC))  
-[Slices and References](example5/example5.go) ([Go Playground](https://play.golang.org/p/zYT3ls_DuV))  
-[Strings and slices](example6/example6.go) ([Go Playground](https://play.golang.org/p/x0Q5ByzxGS))  
-[Variadic functions](example7/example7.go) ([Go Playground](https://play.golang.org/p/58YyAeWjzw))  
-[Range mechanics](example8/example8.go) ([Go Playground](https://play.golang.org/p/cve_NbA6Qn))  
+[Declare and Length](example1/example1.go) ([Go Playground](https://play.golang.org/p/v73cYn6uHLI))  
+[Reference Types](example2/example2.go) ([Go Playground](https://play.golang.org/p/g19Hn9LW-2-))  
+[Appending slices](example4/example4.go) ([Go Playground](https://play.golang.org/p/UVrqIPScg15))  
+[Taking slices of slices](example3/example3.go) ([Go Playground](https://play.golang.org/p/Z1CYb5AkZ3j))  
+[Slices and References](example5/example5.go) ([Go Playground](https://play.golang.org/p/8LPjSmnKQFk))  
+[Strings and slices](example6/example6.go) ([Go Playground](https://play.golang.org/p/1RntHk6UPA5))  
+[Variadic functions](example7/example7.go) ([Go Playground](https://play.golang.org/p/rUjWVBMmxgP))  
+[Range mechanics](example8/example8.go) ([Go Playground](https://play.golang.org/p/QUf-bNnT37F))  
 
 ## Advanced Code Review
 
-[Three index slicing](advanced/example1/example1.go) ([Go Playground](https://play.golang.org/p/QZQIdaTgtG))
+[Three index slicing](advanced/example1/example1.go) ([Go Playground](https://play.golang.org/p/70Sp1QotYSm))
 
 ## Exercises
 
@@ -44,7 +44,7 @@ https://github.com/golang/go/wiki/SliceTricks
 
 **Part B** Declare a slice of five strings and initialize the slice with string literal values. Display all the elements. Take a slice of index one and two and display the index position and value of each element in the new slice.
 
-[Template](exercises/template1/template1.go) ([Go Playground](https://play.golang.org/p/sE06PRtw7h)) | 
-[Answer](exercises/exercise1/exercise1.go) ([Go Playground](https://play.golang.org/p/DLX9f0Lek0))
+[Template](exercises/template1/template1.go) ([Go Playground](https://play.golang.org/p/t8I3xz2jWCl)) | 
+[Answer](exercises/exercise1/exercise1.go) ([Go Playground](https://play.golang.org/p/0xv7GTHHIR_K))
 ___
 All material is licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).

--- a/topics/go/language/slices/example3/example3.go
+++ b/topics/go/language/slices/example3/example3.go
@@ -32,6 +32,14 @@ func main() {
 	// Display the change across all existing slices.
 	inspectSlice(slice1)
 	inspectSlice(slice2)
+
+	fmt.Println("*************************")
+
+	// Make a new slice big enough to hold elements of slice 1 and copy the
+	// values over using the builtin copy function.
+	slice3 := make([]string, len(slice1))
+	copy(slice3, slice1)
+	inspectSlice(slice3)
 }
 
 // inspectSlice exposes the slice header for review.


### PR DESCRIPTION
When covering the "Slices of Slices" section we show how slices can share a backing array and how this can potentially be dangerous. I added a third slice in this example that uses `copy` to ensure the new slice has a different backing.

Maybe this should be moved to a whole new example file?