### PR TITLE
Fix Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ RUN apk add --update --no-cache \
            graphviz \
            ttf-freefont
 WORKDIR /go/src/github.com/ardanlabs/gotraining
-CMD /bin/bash
+CMD /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ RUN apk add --update --no-cache \
            graphviz \
            ttf-freefont
 WORKDIR /go/src/github.com/ardanlabs/gotraining
-CMD /bin/sh
+ENTRYPOINT [ "/bin/sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.1-alpine3.6
+FROM golang:1.9-alpine3.6
 RUN apk add --update --no-cache \
            graphviz \
            ttf-freefont

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ docker build -t ardanlabs/gotraining:latest .
 **Start Docker container**
 ```
 cd $GOPATH/src/github.com/ardanlabs/gotraining
-docker run -i -t -p 8080:8080 -v "$PWD":/go/src/github.com/ardanlabs/gotraining ardanlabs/gotraining:latest /bin/sh
+docker run -i -t -p 8080:8080 -v "$PWD":/go/src/github.com/ardanlabs/gotraining ardanlabs/gotraining:latest
 ```
 
 **What is running**

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ ___
 **Install Docker Toolbox**  
 https://www.docker.com/products/docker-toolbox
 
-**Build Docker container**
+**Build Docker image**
 ```
 # current path is the source root where Dockerfile exists
 docker build -t ardanlabs/gotraining:latest .


### PR DESCRIPTION
Change the Dockerfile CMD from `/bin/bash` to `/bin/sh`, since the bash shell isn't installed in the docker base image we're using (`golang:1.9.1-alpine3.6`).

Before this change, running a container based on the `ardanlabs/gotraining` image would fail with a `/bin/bash: not found` error by default.