### PR TITLE
Remove unnecessary conversion

### DIFF
--- a/topics/go/design/composition/README.md
+++ b/topics/go/design/composition/README.md
@@ -42,7 +42,7 @@ http://golang.org/doc/effective_go.html#embedding
 [Interface Composition](decoupling/example3/example3.go) ([Go Playground](https://play.golang.org/p/s7B4mmIvtj))  
 [Decoupling With Interface Composition](decoupling/example4/example4.go) ([Go Playground](https://play.golang.org/p/pRyZ5UQ_L0))  
 [Remove Interface Pollution](decoupling/example5/example5.go) ([Go Playground](https://play.golang.org/p/K5bbsDnlIM))  
-[More Precise API](decoupling/example6/example6.go) ([Go Playground](https://play.golang.org/p/udStbohP4y))  
+[More Precise API](decoupling/example6/example6.go) ([Go Playground](https://play.golang.org/p/yX_ioKxY9J))
 
 #### Conversion and Assertions
 

--- a/topics/go/design/composition/decoupling/example6/example6.go
+++ b/topics/go/design/composition/decoupling/example6/example6.go
@@ -116,17 +116,17 @@ func Copy(p Puller, s Storer, batch int) error {
 // =============================================================================
 
 func main() {
-	p := Puller(&Xenia{
+	x := Xenia{
 		Host:    "localhost:8000",
 		Timeout: time.Second,
-	})
+	}
 
-	s := Storer(&Pillar{
+	p := Pillar{
 		Host:    "localhost:9000",
 		Timeout: time.Second,
-	})
+	}
 
-	if err := Copy(p, s, 3); err != io.EOF {
+	if err := Copy(&x, &p, 3); err != io.EOF {
 		fmt.Println(err)
 	}
 }


### PR DESCRIPTION
Decoupling example 6 includes an unnecessary conversion of the `Xenia` and `Pillar` types to `Puller` and `Storer`. However Xenia and Pillar already fulfill the `Puller` and `Storer` interfaces and thus don't need the explicit conversion.