### PR TITLE
Add an example of how to sort maps by key

### DIFF
--- a/topics/go/language/maps/README.md
+++ b/topics/go/language/maps/README.md
@@ -19,6 +19,8 @@ http://www.goinggo.net/2013/12/macro-view-of-map-internals-in-go.html
 [Declare, initialize and iterate](example1/example1.go) ([Go Playground](https://play.golang.org/p/EHfkoipKYF))  
 [Map literals and delete](example2/example2.go) ([Go Playground](https://play.golang.org/p/B2klwmqmPZ))  
 [Map key restrictions](example3/example3.go) ([Go Playground](https://play.golang.org/p/LZRHA7FG6s))  
+[Sorting maps by key](example4/example4.go) ([Go Playground](https://play.golang.org/p/EeBJ4Eixzxz))  
+
 
 ## Exercises
 

--- a/topics/go/language/maps/example4/example4.go
+++ b/topics/go/language/maps/example4/example4.go
@@ -1,0 +1,42 @@
+// All material is licensed under the Apache License Version 2.0, January 2004
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Sample program to show how to walk through a
+// map in by alphabetical key order.
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+// user defines a user in the program.
+type user struct {
+	name    string
+	surname string
+}
+
+func main() {
+
+	// Declare and initialize the map with values.
+	users := map[string]user{
+		"Roy":     {"Rob", "Roy"},
+		"Ford":    {"Henry", "Ford"},
+		"Mouse":   {"Mickey", "Mouse"},
+		"Jackson": {"Michael", "Jackson"},
+	}
+
+	// Pull the keys from the map
+	var keys []string
+	for key := range users {
+		keys = append(keys, key)
+	}
+
+	// Sort the keys
+	sort.Strings(keys)
+
+	// Walk through the keys and pull each value from the map
+	for _, key := range keys {
+		fmt.Println(key, users[key])
+	}
+}


### PR DESCRIPTION
When I explain that ranging over maps is random it leads to the question of how you might range over a map in a specific order. This provides one example that can be referenced if necessary. 