### PR TITLE
fix utf-8 import error

### DIFF
--- a/vendor/github.com/theplant/blackfriday/markdown.go
+++ b/vendor/github.com/theplant/blackfriday/markdown.go
@@ -20,7 +20,7 @@ package blackfriday
 
 import (
 	"bytes"
-	"utf8"
+	"unicode/utf8"
 )
 
 const VERSION = "1.0"


### PR DESCRIPTION
when I run gotraining from docker, there is an error as follow
```
/go/src/github.com/ardanlabs/gotraining # go run main.go 
vendor/github.com/theplant/blackfriday/markdown.go:23:2: cannot find package "utf8" in any of:
        /go/src/github.com/ardanlabs/gotraining/vendor/utf8 (vendor tree)
        /usr/local/go/src/utf8 (from $GOROOT)
        /go/src/utf8 (from $GOPATH)
```