### PR TITLE
pointers: Show how Go will conveniently dereference pointers to structs

### DIFF
--- a/topics/go/language/pointers/README.md
+++ b/topics/go/language/pointers/README.md
@@ -111,8 +111,8 @@ https://godoc.org/golang.org/x/tools/go/ssa
 ## Code Review
 
 [Pass by Value](example1/example1.go) ([Go Playground](https://play.golang.org/p/9kxh18hd_BT))  
-[Sharing data I](example2/example2.go) ([Go Playground](https://play.golang.org/p/cbdMiy7TsQ0))  
-[Sharing data II](example3/example3.go) ([Go Playground](https://play.golang.org/p/kwU2jR54c13))  
+[Sharing data I](example2/example2.go) ([Go Playground](https://play.golang.org/p/mJz5RINaimn))  
+[Sharing data II](example3/example3.go) ([Go Playground](https://play.golang.org/p/GpmPICMGMre))  
 [Escape Analysis](example4/example4.go) ([Go Playground](https://play.golang.org/p/qNOw5gEtYhI))  
 [Stack grow](example5/example5.go) ([Go Playground](https://play.golang.org/p/BgIKcFcZ4PO))  
 

--- a/topics/go/language/pointers/example2/example2.go
+++ b/topics/go/language/pointers/example2/example2.go
@@ -26,5 +26,6 @@ func increment(inc *int) {
 
 	// Increment the "value of" count that the "pointer points to".
 	*inc++
+
 	println("inc:\tValue Of[", inc, "]\tAddr Of[", &inc, "]\tValue Points To[", *inc, "]")
 }

--- a/topics/go/language/pointers/example3/example3.go
+++ b/topics/go/language/pointers/example3/example3.go
@@ -39,11 +39,12 @@ func main() {
 // always an address and points to values of type int.
 func increment(logins *int) {
 	*logins++
-	fmt.Printf("&logins[%p] logins[%p] *logins[%d]\n", &logins, logins, *logins)
+	fmt.Printf("&logins[%p] logins[%p] *logins[%d]\n\n", &logins, logins, *logins)
 }
 
 // display declares u as user pointer variable whose value is always an address
 // and points to values of type user.
 func display(u *user) {
 	fmt.Printf("%p\t%+v\n", u, *u)
+	fmt.Printf("Name: %q Email: %q Logins: %d\n\n", u.name, u.email, u.logins)
 }


### PR DESCRIPTION
In example3 we have a `*u` which dereferences a pointer to get to the
underlying struct value. This is good to know but I rarely ever do this.
Instead if a have a pointer variable `u` and I want the `name` property
I will use `u.name` which automatically deference the pointer.

I show this here because it's about this point in the training that
students are envisioning a life of frequent manual pointer dereference
but the reality is more convenient.

I also tweaked the formatting a bit so the output of example3 looks like

```
0xc42008e180    {name:Bill email:bill@ardanlabs.com logins:0}
Name: "Bill" Email: "bill@ardanlabs.com" Logins: 0

&logins[0xc4200a4020] logins[0xc42008e1a0] *logins[1]

0xc42008e180    {name:Bill email:bill@ardanlabs.com logins:1}
Name: "Bill" Email: "bill@ardanlabs.com" Logins: 1

```