### PR TITLE
A minor fix of fanOut/fanOutSem funcs

### DIFF
--- a/topics/go/concurrency/channels/README.md
+++ b/topics/go/concurrency/channels/README.md
@@ -51,7 +51,7 @@ http://www.goinggo.net/2014/02/the-nature-of-channels-in-go.html
 
 ## Code Review
 
-[Basic mechanics](example1/example1.go) ([Go Playground](https://play.golang.org/p/gBY36AXp691))  
+[Basic mechanics](example1/example1.go) ([Go Playground](https://play.golang.org/p/9TbPYvE7GyG))  
 [Tennis game](example2/example2.go) ([Go Playground](https://play.golang.org/p/PvFKD_tNwir))  
 [Relay race](example3/example3.go) ([Go Playground](https://play.golang.org/p/OLdBCGUvzbx))  
 [Fan out pattern](example4/example4.go) ([Go Playground](https://play.golang.org/p/zxzHAHIr3Xj))  

--- a/topics/go/concurrency/channels/README.md
+++ b/topics/go/concurrency/channels/README.md
@@ -51,7 +51,7 @@ http://www.goinggo.net/2014/02/the-nature-of-channels-in-go.html
 
 ## Code Review
 
-[Basic mechanics](example1/example1.go) ([Go Playground](https://play.golang.org/p/BUzXVoBOvaA))  
+[Basic mechanics](example1/example1.go) ([Go Playground](https://play.golang.org/p/gBY36AXp691))  
 [Tennis game](example2/example2.go) ([Go Playground](https://play.golang.org/p/PvFKD_tNwir))  
 [Relay race](example3/example3.go) ([Go Playground](https://play.golang.org/p/OLdBCGUvzbx))  
 [Fan out pattern](example4/example4.go) ([Go Playground](https://play.golang.org/p/zxzHAHIr3Xj))  

--- a/topics/go/concurrency/channels/example1/example1.go
+++ b/topics/go/concurrency/channels/example1/example1.go
@@ -135,10 +135,10 @@ func fanOut() {
 	}
 
 	for emps > 0 {
+		emps--
 		p := <-ch
 		fmt.Println(p)
 		fmt.Println("manager : recv'd signal :", emps)
-		emps--
 	}
 
 	time.Sleep(time.Second)
@@ -170,10 +170,10 @@ func fanOutSem() {
 	}
 
 	for emps > 0 {
+		emps--
 		p := <-ch
 		fmt.Println(p)
 		fmt.Println("manager : recv'd signal :", emps)
-		emps--
 	}
 
 	time.Sleep(time.Second)

--- a/topics/go/concurrency/channels/example1/example1.go
+++ b/topics/go/concurrency/channels/example1/example1.go
@@ -135,8 +135,8 @@ func fanOut() {
 	}
 
 	for emps > 0 {
-		emps--
 		p := <-ch
+		emps--
 		fmt.Println(p)
 		fmt.Println("manager : recv'd signal :", emps)
 	}
@@ -170,8 +170,8 @@ func fanOutSem() {
 	}
 
 	for emps > 0 {
-		emps--
 		p := <-ch
+		emps--
 		fmt.Println(p)
 		fmt.Println("manager : recv'd signal :", emps)
 	}


### PR DESCRIPTION
This PR fixes a minor output bug with `emps` counter.
For instance an output with `emps=5` on [example1.go:126](https://github.com/ardanlabs/gotraining/blob/master/topics/go/concurrency/channels/example1/example1.go#L126)

```sh
employee : sent signal : 0
paper
manager : recv'd signal : 5
employee : sent signal : 2
paper
manager : recv'd signal : 4
employee : sent signal : 1
paper
manager : recv'd signal : 3
paper
manager : recv'd signal : 2
employee : sent signal : 4
employee : sent signal : 3
paper
manager : recv'd signal : 1
```
`employee` sends signals starting from `0` but `manager` receives starting from `1`

P.S. 
Does it worth to change the format to smth like this?
```sh
employee[0]: sent signal "paper"
employee[1]: sent signal "paper"
manager: recv'd signal "paper" from employee[1]
employee[2]: sent signal "paper"
manager: recv'd signal "paper" from employee[0]
manager: recv'd signal "paper" from employee[2]
...
```
