### PR TITLE
Print pointer directly in escape analysis example

### DIFF
--- a/topics/go/language/pointers/README.md
+++ b/topics/go/language/pointers/README.md
@@ -114,7 +114,7 @@ If the GC begins to believe that it can’t finish the collection within the dec
 [Pass by Value](example1/example1.go) ([Go Playground](https://play.golang.org/p/9kxh18hd_BT))  
 [Sharing data I](example2/example2.go) ([Go Playground](https://play.golang.org/p/mJz5RINaimn))  
 [Sharing data II](example3/example3.go) ([Go Playground](https://play.golang.org/p/GpmPICMGMre))  
-[Escape Analysis](example4/example4.go) ([Go Playground](https://play.golang.org/p/EpDUu873YXc))  
+[Escape Analysis](example4/example4.go) ([Go Playground](https://play.golang.org/p/iJwjVswzs3c))  
 [Stack grow](example5/example5.go) ([Go Playground](https://play.golang.org/p/BgIKcFcZ4PO))  
 
 ### Escape Analysis Flaws

--- a/topics/go/language/pointers/example4/example4.go
+++ b/topics/go/language/pointers/example4/example4.go
@@ -15,7 +15,7 @@ func main() {
 	u1 := createUserV1()
 	u2 := createUserV2()
 
-	println("u1", &u1, "u2", &u2)
+	println("u1", &u1, "u2", u2)
 }
 
 // createUserV1 creates a user value and passed


### PR DESCRIPTION
`createUserV2` returns a pointer and the main function should print it directly to show it is the same address as the one printed inside `createUserV2` because it is allocated on heap, the main function was printing the address of the pointer, so the output was confusing, V2 and u2 should be the same.

Before

````text
V1 0x41c770
V2 0x40c030
u1 0x41c7a0 u2 0x41c79c
````

After

````text
V1 0x41c770
V2 0x40c030
u1 0x41c7a0 u2 0x40c030
`````