### PR TITLE
Use a simpler program for showing goroutine time slicing

### DIFF
--- a/topics/go/concurrency/goroutines/README.md
+++ b/topics/go/concurrency/goroutines/README.md
@@ -39,7 +39,7 @@ Goroutines are functions that are created and scheduled to be run independently 
 ## Code Review
 
 [Goroutines and concurrency](example1/example1.go) ([Go Playground](https://play.golang.org/p/4n6G3uRDc83))  
-[Goroutine time slicing](example2/example2.go) ([Go Playground](https://play.golang.org/p/9lkgTwlbX28))  
+[Goroutine time slicing](example2/example2.go) ([Go Playground](https://play.golang.org/p/QtNVo1nb4uQ))  
 [Goroutines and parallelism](example3/example3.go) ([Go Playground](https://play.golang.org/p/ybZ84UcLW81))  
 
 ## Exercises

--- a/topics/go/concurrency/goroutines/example2/example2.go
+++ b/topics/go/concurrency/goroutines/example2/example2.go
@@ -6,10 +6,10 @@
 package main
 
 import (
+	"crypto/sha1"
 	"fmt"
-	"io"
-	"os"
 	"runtime"
+	"strconv"
 	"sync"
 )
 
@@ -29,13 +29,13 @@ func main() {
 
 	// Create the first goroutine and manage its lifecycle here.
 	go func() {
-		printPrime("A")
+		printHashes("A")
 		wg.Done()
 	}()
 
 	// Create the second goroutine and manage its lifecycle here.
 	go func() {
-		printPrime("B")
+		printHashes("B")
 		wg.Done()
 	}()
 
@@ -46,25 +46,22 @@ func main() {
 	fmt.Println("Terminating Program")
 }
 
-// printPrime logs and displays prime numbers for the first 10 numbers.
-func printPrime(prefix string) {
-	file, err := os.Create(prefix)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	defer func() { file.Close(); os.Remove(prefix) }()
-	mw := io.MultiWriter(os.Stdout, file)
+// printHashes calculates the sha1 hash for a range of
+// numbers and prints each in hex encoding.
+func printHashes(prefix string) {
 
-next:
-	for outer := 2; outer < 10; outer++ {
-		for inner := 2; inner < outer; inner++ {
-			if outer%inner == 0 {
-				continue next
-			}
-		}
+	// print each has from 1 to 10. Change this to 50000 and
+	// see how the scheduler behaves.
+	for i := 1; i <= 10; i++ {
 
-		fmt.Fprintf(mw, "%s:%d\n", prefix, outer)
+		// Convert i to a string.
+		num := strconv.Itoa(i)
+
+		// Calculate hash for string num.
+		sum := sha1.Sum([]byte(num))
+
+		// Print prefix: 5-digit-number: hex encoded hash
+		fmt.Printf("%s: %05d: %x\n", prefix, i, sum)
 	}
 
 	fmt.Println("Completed", prefix)


### PR DESCRIPTION
This modified version of goroutines/example2 does sha1+hex for each number in a single loop. Initially it only loops up to 10 and the output is this

```$ go run example2.go
Create Goroutines
Waiting To Finish
B: 00001: 356a192b7913b04c54574d18c28d46e6395428ab
B: 00002: da4b9237bacccdf19c0760cab7aec4a8359010b0
B: 00003: 77de68daecd823babbb58edb1c8e14d7106e83bb
B: 00004: 1b6453892473a467d07372d45eb05abc2031647a
B: 00005: ac3478d69a3c81fa62e60f5c3696165a4e5e6ac4
B: 00006: c1dfd96eea8cc2b62785275bca38ac261256e278
B: 00007: 902ba3cda1883801594b6e1b452790cc53948fda
B: 00008: fe5dbbcea5ce7e2988b8c69bcfdfde8904aabc1f
B: 00009: 0ade7c2cf97f75d009975f4d720d1fa6c19f4897
B: 00010: b1d5781111d84f7b3fe45a0852e59758cd7a87e5
Completed B
A: 00001: 356a192b7913b04c54574d18c28d46e6395428ab
A: 00002: da4b9237bacccdf19c0760cab7aec4a8359010b0
A: 00003: 77de68daecd823babbb58edb1c8e14d7106e83bb
A: 00004: 1b6453892473a467d07372d45eb05abc2031647a
A: 00005: ac3478d69a3c81fa62e60f5c3696165a4e5e6ac4
A: 00006: c1dfd96eea8cc2b62785275bca38ac261256e278
A: 00007: 902ba3cda1883801594b6e1b452790cc53948fda
A: 00008: fe5dbbcea5ce7e2988b8c69bcfdfde8904aabc1f
A: 00009: 0ade7c2cf97f75d009975f4d720d1fa6c19f4897
A: 00010: b1d5781111d84f7b3fe45a0852e59758cd7a87e5
Completed A
Terminating Program
```

When I change the loop to count up to 50,000 I can consistently see the time slicing behavior. On my laptop goroutine B is parked at around 41,000 and on the playground it can get up to about 46,000.

The whole program completes in under 2 seconds and gives a small enough amount of output that I can reasonably pipe it to `less` or similar to show the point where it gets sliced.