### PR TITLE
Readability improvements

### DIFF
--- a/topics/go/concurrency/data_race/README.md
+++ b/topics/go/concurrency/data_race/README.md
@@ -37,11 +37,11 @@ This content is provided by Scott Meyers from his talk in 2014 at Dive:
 
 ## Code Review
 
-[Data Race](example1/example1.go) ([Go Playground](https://play.golang.org/p/zahCnOjS4Q1))  
-[Atomic Increments](example2/example2.go) ([Go Playground](https://play.golang.org/p/DkqwruQwS-N))  
-[Mutex](example3/example3.go) ([Go Playground](https://play.golang.org/p/T15uvr3SxHa))  
-[Read/Write Mutex](example4/example4.go) ([Go Playground](https://play.golang.org/p/_n32wetlmSs))  
-[Map Data Race](example5/example5.go) ([Go Playground](https://play.golang.org/p/ktWRjcJWNjw))
+[Data Race](example1/example1.go) ([Go Playground](https://play.golang.org/p/czqXM5wOspX))    
+[Atomic Increments](example2/example2.go) ([Go Playground](https://play.golang.org/p/5ZtLaX7zxt7))    
+[Mutex](example3/example3.go) ([Go Playground](https://play.golang.org/p/ZKE2v9H4oS-))    
+[Read/Write Mutex](example4/example4.go) ([Go Playground](https://play.golang.org/p/_n32wetlmSs))    
+[Map Data Race](example5/example5.go) ([Go Playground](https://play.golang.org/p/ktWRjcJWNjw))    
 
 ## Advanced Code Review
 

--- a/topics/go/concurrency/data_race/example1/example1.go
+++ b/topics/go/concurrency/data_race/example1/example1.go
@@ -25,9 +25,9 @@ func main() {
 	wg.Add(grs)
 
 	// Create two goroutines.
-	for i := 0; i < grs; i++ {
+	for g := 0; g < grs; g++ {
 		go func() {
-			for count := 0; count < 2; count++ {
+			for i := 0; i < 2; i++ {
 
 				// Capture the value of Counter.
 				value := counter

--- a/topics/go/concurrency/data_race/example2/example2.go
+++ b/topics/go/concurrency/data_race/example2/example2.go
@@ -24,9 +24,9 @@ func main() {
 	wg.Add(grs)
 
 	// Create two goroutines.
-	for i := 0; i < grs; i++ {
+	for g := 0; g < grs; g++ {
 		go func() {
-			for count := 0; count < 2; count++ {
+			for i := 0; i < 2; i++ {
 				atomic.AddInt64(&counter, 1)
 			}
 

--- a/topics/go/concurrency/data_race/example3/example3.go
+++ b/topics/go/concurrency/data_race/example3/example3.go
@@ -26,9 +26,9 @@ func main() {
 	wg.Add(grs)
 
 	// Create two goroutines.
-	for i := 0; i < grs; i++ {
+	for g := 0; g < grs; g++ {
 		go func() {
-			for count := 0; count < 2; count++ {
+			for i := 0; i < 2; i++ {
 
 				// Only allow one goroutine through this critical section at a time.
 				mutex.Lock()


### PR DESCRIPTION
Loop variable `count` too similar to package-level variable `counter`, taking attention away from the lesson in these examples.