### PR TITLE
Fix goroutine id output

### DIFF
--- a/topics/go/concurrency/data_race/README.md
+++ b/topics/go/concurrency/data_race/README.md
@@ -40,7 +40,7 @@ This content is provided by Scott Meyers from his talk in 2014 at Dive:
 [Data Race](example1/example1.go) ([Go Playground](https://play.golang.org/p/czqXM5wOspX))    
 [Atomic Increments](example2/example2.go) ([Go Playground](https://play.golang.org/p/5ZtLaX7zxt7))    
 [Mutex](example3/example3.go) ([Go Playground](https://play.golang.org/p/ZKE2v9H4oS-))    
-[Read/Write Mutex](example4/example4.go) ([Go Playground](https://play.golang.org/p/_n32wetlmSs))    
+[Read/Write Mutex](example4/example4.go) ([Go Playground](https://play.golang.org/p/Rv8Wf8hw6MK))    
 [Map Data Race](example5/example5.go) ([Go Playground](https://play.golang.org/p/ktWRjcJWNjw))    
 
 ## Advanced Code Review

--- a/topics/go/concurrency/data_race/example4/example4.go
+++ b/topics/go/concurrency/data_race/example4/example4.go
@@ -44,11 +44,11 @@ func main() {
 
 	// Create eight reader goroutines.
 	for i := 0; i < 8; i++ {
-		go func() {
+		go func(id int) {
 			for {
-				reader(i)
+				reader(id)
 			}
-		}()
+		}(i)
 	}
 
 	// Wait for the write goroutine to finish.


### PR DESCRIPTION
Hopefully (!!) this shows you've taught me well...

This PR fixes incorrect output of the goroutine ID. Typically the output shows all goroutine's have an ID of '8' which is clearly not what's intended. 

Cause:

```
$ go vet
# github.com/ardanlabs/gotraining/topics/go/concurrency/data_race/example4
./example4.go:49:12: loop variable i captured by func literal
```

Using the Go race detector:

```
$ go build -race
$ ./example4
==================
WARNING: DATA RACE
Read at 0x00c0000d6010 by goroutine 8:
  main.main.func2()
      /Users/dan/working/go/src/github.com/DanHam/gotraining/topics/go/concurrency/data_race/example4/example4.go:49 +0x38

Previous write at 0x00c0000d6010 by main goroutine:
  main.main()
      /Users/dan/working/go/src/github.com/DanHam/gotraining/topics/go/concurrency/data_race/example4/example4.go:46 +0x114

Goroutine 8 (running) created at:
  main.main()
      /Users/dan/working/go/src/github.com/DanHam/gotraining/topics/go/concurrency/data_race/example4/example4.go:47 +0xf0
==================
```