### PR TITLE
fix URL in reading

### DIFF
--- a/reading/README.md
+++ b/reading/README.md
@@ -76,7 +76,7 @@ There is a ton of links to extra reading and videos through out the material. Oc
 ### Assembly
 
 [Go Assembly by Example](http://davidwong.fr/goasm/) - David Wong  
-[Quick intro to Go assembly](https://blog.hackercat.ninja/post/quick_intro_to_go_assembly/)  
+[Quick intro to Go assembly](https://blog.hackercat.ninja/2018/quick_intro_to_go_assembly/)  
 [The Go low-level calling convention on x86-64](http://science.raphael.poss.name/go-calling-convention-x86-64.html) - Raphael ‘kena’ Poss  
 
 ### Buffer Bloat - 2011


### PR DESCRIPTION
I found [Quick intro to Go assembly](https://blog.hackercat.ninja/2018/quick_intro_to_go_assembly/)'s URL is changed and encountered 404 when I visited this URL.
So I wrote this pull request in order to fix this 404 error.