### PR TITLE
fix: removed taking pointer of a pointer

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -46,6 +46,7 @@ Daniela Petruzalek <daniela.petruzalek@gmail.com>
 Davor Kapsa <davor.kapsa@gmail.com>
 DFenniak <donald@getjobber.com>
 Diwant Vaidya <diwant@gmail.com>
+Dmitry Egorov <egorovdmi@gmail.com>
 Dmytro Tananayskiy <dmitriyminer@gmail.com>
 dtlaycock <dtlaycock@users.noreply.github.com>
 Ed Gonzalez <ed@ardanlabs.com>

--- a/topics/go/packages/context/README.md
+++ b/topics/go/packages/context/README.md
@@ -39,6 +39,6 @@ The package context defines the Context type, which carries deadlines, cancellat
 Use the template and follow the directions. You will be writing a web handler that performs a mock database call but will timeout based on a context if the call takes too long. You will also save state into the context.
 
 [Template](exercises/template1/template1.go) ([Go Playground](https://play.golang.org/p/jIkgYBhqMNy)) | 
-[Answer](exercises/exercise1/exercise1.go) ([Go Playground](https://play.golang.org/p/eJamC6Aleu5))  
+[Answer](exercises/exercise1/exercise1.go) ([Go Playground](https://play.golang.org/p/J5j1ygl6LtN))  
 ___
 All material is licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).

--- a/topics/go/packages/context/exercises/exercise1/exercise1.go
+++ b/topics/go/packages/context/exercises/exercise1/exercise1.go
@@ -73,7 +73,7 @@ func findUser(rw http.ResponseWriter, r *http.Request) {
 	case u := <-ch:
 
 		// Respond with the user.
-		sendResponse(rw, &u, http.StatusOK)
+		sendResponse(rw, u, http.StatusOK)
 		log.Println("Sent StatusOK")
 		return
 


### PR DESCRIPTION
I've found a weird thing. The channel receives a pointer to a user structure, but on the line 76 the pointer of a pointer has been taken and passed as an argument to the sendResponse method. Was it done on purpose or I fixed it here correctly?
