### PR TITLE
Fix typo in Kevlin Henney's name

### DIFF
--- a/topics/go/testing/tests/README.md
+++ b/topics/go/testing/tests/README.md
@@ -14,7 +14,7 @@ Testing is built right into the go tools and the standard library. Testing needs
 
 ## Quotes
 
-_"A unit test is a test of behavior whose success or failure is wholly determined by the correctness of the test and the correctness of the unit under test." - Kevin Henney_
+_"A unit test is a test of behavior whose success or failure is wholly determined by the correctness of the test and the correctness of the unit under test." - Kevlin Henney_
 
 ## Links
 


### PR DESCRIPTION
The name is "Kevlin", not "Kevin". See https://twitter.com/KevlinHenney