### PR TITLE
Prevent duplicates in binary tree

### DIFF
--- a/topics/go/algorithms/data/tree/binary/binary.go
+++ b/topics/go/algorithms/data/tree/binary/binary.go
@@ -104,8 +104,10 @@ func (n *node) insert(t *Tree, value int) *node {
 	switch {
 	case value < n.Value:
 		n.left = n.left.insert(t, value)
-	default:
+	case value > n.Value:
 		n.right = n.right.insert(t, value)
+	default:
+		return n.rebalance()
 	}
 	n.level = max(n.left.height(), n.right.height()) + 1
 


### PR DESCRIPTION
Thank you for the work on this. It was nice to study binary tree implementation in Go.

This change disallows duplicates in the binary tree.

The following values:

```
values := []int{65, 65, 65, 65, 65, 45, 35, 75, 85, 78, 95}
```

Will produce the following binary tree.

```
> go run main.go 
        75
     /      \
    45      85
   /  \    /  \
  35  65  78  95

Pre-order : [75 45 35 65 85 78 95]
In-order  : [35 45 65 75 78 85 95]
Post-order: [35 65 45 78 95 85 75]
```