### PR TITLE
Print in different colors for better visibility

### DIFF
--- a/topics/go/concurrency/goroutines/example1/example1.go
+++ b/topics/go/concurrency/goroutines/example1/example1.go
@@ -50,7 +50,8 @@ func lowercase() {
 	// Display the alphabet three times
 	for count := 0; count < 3; count++ {
 		for r := 'a'; r <= 'z'; r++ {
-			fmt.Printf("%c ", r)
+			// Blue
+			fmt.Printf("\033[32m%c\033[39m ", r)
 		}
 	}
 }
@@ -61,7 +62,8 @@ func uppercase() {
 	// Display the alphabet three times
 	for count := 0; count < 3; count++ {
 		for r := 'A'; r <= 'Z'; r++ {
-			fmt.Printf("%c ", r)
+			// Red
+			fmt.Printf("\033[31m%c\033[39m ", r)
 		}
 	}
 }

--- a/topics/go/concurrency/goroutines/example1/example1.go
+++ b/topics/go/concurrency/goroutines/example1/example1.go
@@ -50,8 +50,7 @@ func lowercase() {
 	// Display the alphabet three times
 	for count := 0; count < 3; count++ {
 		for r := 'a'; r <= 'z'; r++ {
-			// Blue
-			fmt.Printf("\033[32m%c\033[39m ", r)
+			fmt.Printf("%c ", r)
 		}
 	}
 }
@@ -62,8 +61,7 @@ func uppercase() {
 	// Display the alphabet three times
 	for count := 0; count < 3; count++ {
 		for r := 'A'; r <= 'Z'; r++ {
-			// Red
-			fmt.Printf("\033[31m%c\033[39m ", r)
+			fmt.Printf("%c ", r)
 		}
 	}
 }

--- a/topics/go/concurrency/goroutines/example1/scripts/color.go
+++ b/topics/go/concurrency/goroutines/example1/scripts/color.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	c := color{os.Stdout}
+	io.Copy(&c, os.Stdin)
+}
+
+func (c *color) Write(buf []byte) (int, error) {
+	for _, b := range buf {
+		switch {
+		case b >= 'A' && b <= 'Z':
+			fmt.Fprintf(c.w, "\033[32m%c\033[39m", b)
+		case b >= 'a' && b <= 'z':
+			fmt.Fprintf(c.w, "\033[31m%c\033[39m", b)
+		default:
+			fmt.Fprintf(c.w, "%c", b)
+		}
+	}
+
+	return len(buf), nil
+}
+
+type color struct {
+	w io.Writer
+}

--- a/topics/go/concurrency/goroutines/example1/scripts/color.sh
+++ b/topics/go/concurrency/goroutines/example1/scripts/color.sh
@@ -1,0 +1,13 @@
+while IFS= read -r line; do
+    for i in $(seq 0 $((${#line} - 1))); do
+	char="${line:i:1}"
+	if [[ "$char" =~ [A-Z] ]]; then
+	    printf "\033[32m%c\033[0m" "$char"
+	elif [[ "$char" =~ [a-z] ]]; then
+	    printf "\033[31m%c\033[0m" "$char"
+	else
+	    printf "$char"
+	fi
+    done
+    echo ""
+done


### PR DESCRIPTION
Print the lower case letter in blue and the upper ones in red for better visibility.
This will work on on POSIX terminals (e.g. *not* on the playground)