### PR TITLE
Update go/profiling/trace README.md

### DIFF
--- a/topics/go/profiling/trace/README.md
+++ b/topics/go/profiling/trace/README.md
@@ -6,7 +6,7 @@ The tracing can help identify not only what is happening but also what is not ha
 
 Review this post to gain basic skills.
 
-[go tool trace](https://making.pusher.com/go-tool-trace/) - Will Sewell  
+[go tool trace]([https://making.pusher.com/go-tool-trace/](https://web.archive.org/web/20220826224706/https://making.pusher.com/go-tool-trace/) - Will Sewell  
 [Debugging Latency in Go 1.11](https://medium.com/observability/debugging-latency-in-go-1-11-9f97a7910d68) - JBD
 
 ## Trace Command


### PR DESCRIPTION
The go tool trace link is broken. 

This PR updates the link to something on web archive, which I found on Will Sewell's blog [here](https://willsewell.com/blog.html)